### PR TITLE
M10.2: GraphDiff DOT + Mermaid export (#5)

### DIFF
--- a/meshant/graph/export.go
+++ b/meshant/graph/export.go
@@ -23,6 +23,8 @@
 //	if err := graph.PrintGraphJSON(&buf, g); err != nil { ... }
 //	if err := graph.PrintGraphDOT(&buf, g); err != nil { ... }
 //	if err := graph.PrintGraphMermaid(&buf, g); err != nil { ... }
+//	if err := graph.PrintDiffDOT(&buf, d); err != nil { ... }
+//	if err := graph.PrintDiffMermaid(&buf, d); err != nil { ... }
 package graph
 
 import (
@@ -215,6 +217,287 @@ func PrintGraphMermaid(w io.Writer, g MeshGraph) error {
 
 	_, err := io.WriteString(w, b.String())
 	return err
+}
+
+// PrintDiffDOT writes d as a Graphviz DOT digraph to w.
+//
+// The output records what changed between two situated cuts:
+//   - Added nodes in green/bold
+//   - Removed nodes in red/dashed
+//   - Persisted nodes with a "name (N→M)" appearance count label
+//   - Added edges as Cartesian-product arcs with green color
+//   - Removed edges as Cartesian-product arcs with red/dashed color
+//   - Shadow shifts in a cluster_shadow_shifts subgraph (omitted if empty)
+//     with per-kind colors: emerged=red, submerged=green, reason-changed=orange
+//
+// Two comment lines at the top record the From and To cuts using dotCutComment.
+// All user-derived strings (names, labels) are sanitized to prevent injection.
+func PrintDiffDOT(w io.Writer, d GraphDiff) error {
+	var b strings.Builder
+
+	// Two-line comment: From and To cuts.
+	b.WriteString("// From: ")
+	b.WriteString(dotCutComment(d.From))
+	b.WriteString("\n// To: ")
+	b.WriteString(dotCutComment(d.To))
+	b.WriteString("\ndigraph {\n")
+
+	// Sort added nodes for deterministic output.
+	addedNodes := make([]string, len(d.NodesAdded))
+	copy(addedNodes, d.NodesAdded)
+	sort.Strings(addedNodes)
+
+	// Emit added nodes: green/bold with "(added)" label.
+	for _, name := range addedNodes {
+		fmt.Fprintf(&b, "  %s [label=%s, color=green, style=bold]\n",
+			dotQuote(stripNewlines(name)),
+			dotQuote(fmt.Sprintf("%s (added)", stripNewlines(name))),
+		)
+	}
+
+	// Sort removed nodes for deterministic output.
+	removedNodes := make([]string, len(d.NodesRemoved))
+	copy(removedNodes, d.NodesRemoved)
+	sort.Strings(removedNodes)
+
+	// Emit removed nodes: red/dashed with "(removed)" label.
+	for _, name := range removedNodes {
+		fmt.Fprintf(&b, "  %s [label=%s, color=red, style=dashed]\n",
+			dotQuote(stripNewlines(name)),
+			dotQuote(fmt.Sprintf("%s (removed)", stripNewlines(name))),
+		)
+	}
+
+	// Sort persisted nodes for deterministic output.
+	persistedNodes := make([]PersistedNode, len(d.NodesPersisted))
+	copy(persistedNodes, d.NodesPersisted)
+	sort.Slice(persistedNodes, func(i, j int) bool { return persistedNodes[i].Name < persistedNodes[j].Name })
+
+	// Emit persisted nodes with appearance count label "name (N→M)".
+	for _, p := range persistedNodes {
+		fmt.Fprintf(&b, "  %s [label=%s]\n",
+			dotQuote(stripNewlines(p.Name)),
+			dotQuote(fmt.Sprintf("%s (%d→%d)", stripNewlines(p.Name), p.CountFrom, p.CountTo)),
+		)
+	}
+
+	// Emit added edges as Cartesian product with green/bold style.
+	for _, edge := range d.EdgesAdded {
+		label := dotQuote(truncateLabel(stripNewlines(edge.WhatChanged)))
+		for _, src := range edge.Sources {
+			for _, tgt := range edge.Targets {
+				fmt.Fprintf(&b, "  %s -> %s [label=%s, color=green, style=bold]\n",
+					dotQuote(stripNewlines(src)), dotQuote(stripNewlines(tgt)), label)
+			}
+		}
+	}
+
+	// Emit removed edges as Cartesian product with red/dashed style.
+	for _, edge := range d.EdgesRemoved {
+		label := dotQuote(truncateLabel(stripNewlines(edge.WhatChanged)))
+		for _, src := range edge.Sources {
+			for _, tgt := range edge.Targets {
+				fmt.Fprintf(&b, "  %s -> %s [label=%s, color=red, style=dashed]\n",
+					dotQuote(stripNewlines(src)), dotQuote(stripNewlines(tgt)), label)
+			}
+		}
+	}
+
+	// Shadow shifts subgraph — only emitted if there are shifts.
+	// Colors per kind: emerged=green (now visible — consistent with added-node convention),
+	// submerged=red (now hidden — consistent with removed-node convention),
+	// reason-changed=orange (shifted meaning but still in shadow).
+	if len(d.ShadowShifts) > 0 {
+		b.WriteString("  subgraph cluster_shadow_shifts {\n")
+		b.WriteString("    label=\"shadow shifts\"\n")
+		b.WriteString("    style=dashed\n")
+		b.WriteString("    color=grey\n")
+		for _, ss := range d.ShadowShifts {
+			color := "orange"
+			switch ss.Kind {
+			case ShadowShiftEmerged:
+				color = "green"
+			case ShadowShiftSubmerged:
+				color = "red"
+			}
+			fmt.Fprintf(&b, "    %s [label=%s, color=%s]\n",
+				dotQuote(stripNewlines(ss.Name)),
+				dotQuote(fmt.Sprintf("%s (%s)", stripNewlines(ss.Name), stripNewlines(string(ss.Kind)))),
+				color,
+			)
+		}
+		b.WriteString("  }\n")
+	}
+
+	b.WriteString("}\n")
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// PrintDiffMermaid writes d as a Mermaid flowchart (LR direction) to w.
+//
+// Node IDs are sanitized for Mermaid compatibility (same rules as
+// PrintGraphMermaid). The output encodes diff semantics through:
+//   - Added node declarations with "(added)" label + green stroke style
+//   - Removed node declarations with "(removed)" label + red dashed style
+//   - Persisted node declarations with "(N→M)" count label
+//   - Added edges as --> solid arrows with labels
+//   - Removed edges as -.-> dashed arrows with labels
+//   - Shadow shifts in a ShadowShifts subgraph (omitted if empty)
+//
+// Two %% comment lines at the top record the From and To cuts.
+// All user-derived strings are sanitized to prevent click-directive injection.
+func PrintDiffMermaid(w io.Writer, d GraphDiff) error {
+	var b strings.Builder
+
+	// Two-line comment: From and To cuts.
+	b.WriteString("%% From: ")
+	b.WriteString(dotCutComment(d.From))
+	b.WriteString("\n%% To: ")
+	b.WriteString(dotCutComment(d.To))
+	b.WriteString("\nflowchart LR\n")
+
+	// Build a sanitized-ID map for all names in the diff.
+	allNames := collectAllDiffNames(d)
+	idMap := buildMermaidIDMap(allNames)
+
+	// Emit added node declarations with "(added)" label.
+	addedNodes := make([]string, len(d.NodesAdded))
+	copy(addedNodes, d.NodesAdded)
+	sort.Strings(addedNodes)
+	for _, name := range addedNodes {
+		fmt.Fprintf(&b, "  %s[\"%s (added)\"]\n",
+			idMap[name],
+			mermaidLabel(name),
+		)
+	}
+
+	// Emit removed node declarations with "(removed)" label.
+	removedNodes := make([]string, len(d.NodesRemoved))
+	copy(removedNodes, d.NodesRemoved)
+	sort.Strings(removedNodes)
+	for _, name := range removedNodes {
+		fmt.Fprintf(&b, "  %s[\"%s (removed)\"]\n",
+			idMap[name],
+			mermaidLabel(name),
+		)
+	}
+
+	// Emit persisted node declarations with "(N→M)" count label.
+	persistedNodes := make([]PersistedNode, len(d.NodesPersisted))
+	copy(persistedNodes, d.NodesPersisted)
+	sort.Slice(persistedNodes, func(i, j int) bool { return persistedNodes[i].Name < persistedNodes[j].Name })
+	for _, p := range persistedNodes {
+		fmt.Fprintf(&b, "  %s[\"%s (%d→%d)\"]\n",
+			idMap[p.Name],
+			mermaidLabel(p.Name),
+			p.CountFrom,
+			p.CountTo,
+		)
+	}
+
+	// Emit style directives for added nodes (green stroke) and removed nodes
+	// (red dashed stroke). These follow all node declarations.
+	for _, name := range addedNodes {
+		fmt.Fprintf(&b, "  style %s stroke:green,stroke-width:3px\n", idMap[name])
+	}
+	for _, name := range removedNodes {
+		fmt.Fprintf(&b, "  style %s stroke:red,stroke-dasharray:5\n", idMap[name])
+	}
+
+	// Emit added edges as solid --> arrows (Cartesian product).
+	for _, edge := range d.EdgesAdded {
+		label := mermaidLabel(truncateLabel(edge.WhatChanged))
+		for _, src := range edge.Sources {
+			for _, tgt := range edge.Targets {
+				fmt.Fprintf(&b, "  %s --> |\"%s\"| %s\n",
+					idMap[src], label, idMap[tgt])
+			}
+		}
+	}
+
+	// Emit removed edges as dashed -.-> arrows (Cartesian product).
+	for _, edge := range d.EdgesRemoved {
+		label := mermaidLabel(truncateLabel(edge.WhatChanged))
+		for _, src := range edge.Sources {
+			for _, tgt := range edge.Targets {
+				fmt.Fprintf(&b, "  %s -.-> |\"%s\"| %s\n",
+					idMap[src], label, idMap[tgt])
+			}
+		}
+	}
+
+	// Shadow shifts subgraph — only emitted if there are shifts.
+	// Per-node style directives mirror the DOT color convention:
+	// emerged=green, submerged=red, reason-changed=orange.
+	if len(d.ShadowShifts) > 0 {
+		b.WriteString("  subgraph ShadowShifts\n")
+		for _, ss := range d.ShadowShifts {
+			// Label describes both the name and shift kind for readability.
+			fmt.Fprintf(&b, "    %s[\"%s (%s)\"]\n",
+				idMap[ss.Name],
+				mermaidLabel(ss.Name),
+				mermaidLabel(string(ss.Kind)),
+			)
+		}
+		b.WriteString("  end\n")
+		// Style directives for shadow shift nodes (after subgraph block).
+		for _, ss := range d.ShadowShifts {
+			color := "orange"
+			switch ss.Kind {
+			case ShadowShiftEmerged:
+				color = "green"
+			case ShadowShiftSubmerged:
+				color = "red"
+			}
+			fmt.Fprintf(&b, "  style %s stroke:%s,stroke-dasharray:5\n", idMap[ss.Name], color)
+		}
+	}
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// collectAllDiffNames returns all element names that appear in a GraphDiff:
+// added/removed node names, persisted node names, edge sources/targets, and
+// shadow shift names. Returns sorted, deduplicated list.
+// This ensures every name referenced in the diagram gets a sanitized Mermaid ID.
+func collectAllDiffNames(d GraphDiff) []string {
+	seen := make(map[string]bool)
+	for _, name := range d.NodesAdded {
+		seen[name] = true
+	}
+	for _, name := range d.NodesRemoved {
+		seen[name] = true
+	}
+	for _, p := range d.NodesPersisted {
+		seen[p.Name] = true
+	}
+	for _, edge := range d.EdgesAdded {
+		for _, s := range edge.Sources {
+			seen[s] = true
+		}
+		for _, t := range edge.Targets {
+			seen[t] = true
+		}
+	}
+	for _, edge := range d.EdgesRemoved {
+		for _, s := range edge.Sources {
+			seen[s] = true
+		}
+		for _, t := range edge.Targets {
+			seen[t] = true
+		}
+	}
+	for _, ss := range d.ShadowShifts {
+		seen[ss.Name] = true
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // --- helpers ---

--- a/meshant/graph/export_diff_test.go
+++ b/meshant/graph/export_diff_test.go
@@ -1,0 +1,529 @@
+// Package graph_test — export_diff_test.go tests PrintDiffDOT and PrintDiffMermaid.
+//
+// All tests follow the black-box convention: only the exported API of the graph
+// package is exercised. errWriter is defined in export_test.go (same package).
+package graph_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/graph"
+)
+
+// mustParseTime is defined in export_test.go — available here via the shared
+// graph_test package.
+
+// buildDiffWithAllKinds constructs a non-trivial GraphDiff that has nodes
+// added, removed, persisted, edges added and removed, and shadow shifts of
+// all three kinds (emerged, submerged, reason-changed).
+func buildDiffWithAllKinds(t *testing.T) graph.GraphDiff {
+	t.Helper()
+	d := buildTestDiff(t) // defined in export_test.go
+
+	// Add a submerged and reason-changed shadow shift alongside the emerged one.
+	d.ShadowShifts = append(d.ShadowShifts,
+		graph.ShadowShift{
+			Name:        "legacy-sensor",
+			Kind:        graph.ShadowShiftSubmerged,
+			ToReasons:   []graph.ShadowReason{graph.ShadowReasonObserver},
+		},
+		graph.ShadowShift{
+			Name:        "relay-station",
+			Kind:        graph.ShadowShiftReasonChanged,
+			FromReasons: []graph.ShadowReason{graph.ShadowReasonObserver},
+			ToReasons:   []graph.ShadowReason{graph.ShadowReasonTimeWindow},
+		},
+	)
+	return d
+}
+
+// --- PrintDiffDOT tests ---
+
+// TestPrintDiffDOT_Basic verifies that a non-trivial diff produces valid DOT
+// output containing the digraph block, green added nodes, red removed nodes,
+// and persisted nodes with count labels.
+func TestPrintDiffDOT_Basic(t *testing.T) {
+	d := buildTestDiff(t)
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffDOT(&buf, d); err != nil {
+		t.Fatalf("PrintDiffDOT: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "digraph {") {
+		t.Errorf("expected 'digraph {' in DOT output, got:\n%s", out)
+	}
+	// Added node: evacuation-order — should have color=green
+	if !strings.Contains(out, "color=green") {
+		t.Errorf("expected 'color=green' for added node in DOT output, got:\n%s", out)
+	}
+	// Removed node: old-model — should have color=red
+	if !strings.Contains(out, "color=red") {
+		t.Errorf("expected 'color=red' for removed node in DOT output, got:\n%s", out)
+	}
+	// Persisted node: storm-model-alpha with count label "2→3"
+	if !strings.Contains(out, "storm-model-alpha") {
+		t.Errorf("expected persisted node 'storm-model-alpha' in DOT output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2→3") {
+		t.Errorf("expected count label '2→3' for persisted node, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffDOT_EmptyDiff verifies that an empty GraphDiff produces a valid
+// minimal DOT digraph without error.
+func TestPrintDiffDOT_EmptyDiff(t *testing.T) {
+	var buf bytes.Buffer
+	if err := graph.PrintDiffDOT(&buf, graph.GraphDiff{}); err != nil {
+		t.Fatalf("PrintDiffDOT on empty diff: unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "digraph {") {
+		t.Errorf("expected 'digraph {' even for empty diff, got:\n%s", out)
+	}
+	if !strings.Contains(out, "}") {
+		t.Errorf("expected closing '}' in DOT output, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffDOT_ShadowShifts verifies that all three shadow shift kinds
+// (emerged, submerged, reason-changed) render inside cluster_shadow_shifts
+// with correct colors: emerged=green (now visible, consistent with added),
+// submerged=red (now hidden, consistent with removed), reason-changed=orange.
+func TestPrintDiffDOT_ShadowShifts(t *testing.T) {
+	d := buildDiffWithAllKinds(t)
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffDOT(&buf, d); err != nil {
+		t.Fatalf("PrintDiffDOT: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "cluster_shadow_shifts") {
+		t.Errorf("expected 'cluster_shadow_shifts' subgraph in DOT output, got:\n%s", out)
+	}
+	// Per-element color assertions: check each shift node's line has the right color.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "evacuation-shelter-b") && strings.Contains(line, "[label=") {
+			// emerged → green (consistent with added-node convention)
+			if !strings.Contains(line, "color=green") {
+				t.Errorf("emerged shift 'evacuation-shelter-b' should have color=green, got: %q", line)
+			}
+		}
+		if strings.Contains(line, "legacy-sensor") && strings.Contains(line, "[label=") {
+			// submerged → red (consistent with removed-node convention)
+			if !strings.Contains(line, "color=red") {
+				t.Errorf("submerged shift 'legacy-sensor' should have color=red, got: %q", line)
+			}
+		}
+		if strings.Contains(line, "relay-station") && strings.Contains(line, "[label=") {
+			// reason-changed → orange
+			if !strings.Contains(line, "color=orange") {
+				t.Errorf("reason-changed shift 'relay-station' should have color=orange, got: %q", line)
+			}
+		}
+	}
+}
+
+// TestPrintDiffDOT_NoShadowShifts verifies that the cluster_shadow_shifts
+// subgraph is NOT emitted when there are no shadow shifts.
+func TestPrintDiffDOT_NoShadowShifts(t *testing.T) {
+	d := buildTestDiff(t)
+	d.ShadowShifts = nil
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffDOT(&buf, d); err != nil {
+		t.Fatalf("PrintDiffDOT: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "cluster_shadow_shifts") {
+		t.Errorf("expected NO 'cluster_shadow_shifts' for diff with no shadow shifts, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffDOT_MultiSourceEdges verifies that an added edge with 2 sources
+// and 2 targets produces 4 arcs (2×2 Cartesian product).
+func TestPrintDiffDOT_MultiSourceEdges(t *testing.T) {
+	d := graph.GraphDiff{
+		EdgesAdded: []graph.Edge{
+			{
+				TraceID:     "aaaaaaaa-0000-4000-8000-000000000001",
+				WhatChanged: "multi source action",
+				Sources:     []string{"src-a", "src-b"},
+				Targets:     []string{"tgt-x", "tgt-y"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffDOT(&buf, d); err != nil {
+		t.Fatalf("PrintDiffDOT: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	arcCount := strings.Count(out, "->")
+	if arcCount != 4 {
+		t.Errorf("expected 4 arcs for 2×2 Cartesian product, got %d in:\n%s", arcCount, out)
+	}
+}
+
+// TestPrintDiffDOT_TwoCutComment verifies that PrintDiffDOT emits two comment
+// lines — one for the From cut and one for the To cut — at the top of the output.
+func TestPrintDiffDOT_TwoCutComment(t *testing.T) {
+	d := buildTestDiff(t)
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffDOT(&buf, d); err != nil {
+		t.Fatalf("PrintDiffDOT: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	commentCount := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "// ") {
+			commentCount++
+		}
+	}
+	if commentCount < 2 {
+		t.Errorf("expected at least 2 comment lines (From and To), got %d in:\n%s", commentCount, out)
+	}
+	if !strings.Contains(out, "// From:") {
+		t.Errorf("expected '// From:' comment line in DOT output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "// To:") {
+		t.Errorf("expected '// To:' comment line in DOT output, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffDOT_LongEdgeLabel verifies that WhatChanged strings longer than
+// 40 runes are truncated with "..." in DOT edge labels.
+func TestPrintDiffDOT_LongEdgeLabel(t *testing.T) {
+	longLabel := strings.Repeat("x", 50)
+	d := graph.GraphDiff{
+		EdgesAdded: []graph.Edge{
+			{
+				TraceID:     "aaaaaaaa-0000-4000-8000-000000000001",
+				WhatChanged: longLabel,
+				Sources:     []string{"a"},
+				Targets:     []string{"b"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffDOT(&buf, d); err != nil {
+		t.Fatalf("PrintDiffDOT: unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "...") {
+		t.Errorf("expected truncated label with '...' for 50-char label, got:\n%s", buf.String())
+	}
+}
+
+// TestPrintDiffDOT_WriteError verifies that PrintDiffDOT propagates a write
+// error from the underlying io.Writer back to the caller without swallowing it.
+func TestPrintDiffDOT_WriteError(t *testing.T) {
+	sentinel := errors.New("disk full")
+	w := errWriter{err: sentinel}
+
+	err := graph.PrintDiffDOT(w, graph.GraphDiff{})
+	if err == nil {
+		t.Fatal("PrintDiffDOT: expected error from failing writer, got nil")
+	}
+}
+
+// TestPrintDiffDOT_NewlineInjection verifies that crafted node names containing
+// newlines have the newlines stripped before reaching DOT output. A newline
+// in a node name could split a DOT label line in two, with the second line
+// becoming raw DOT syntax (e.g. an injected arc).
+//
+// The test confirms that the entire crafted name appears as a single DOT node
+// declaration (no extra raw lines), i.e. there is exactly one declaration line
+// for the node and no extra lines that start with a bare quote followed by
+// a standalone DOT arc token.
+func TestPrintDiffDOT_NewlineInjection(t *testing.T) {
+	// The newline in the name, if not stripped, would produce a second DOT
+	// line: "x" -> "y" [label="injected"] — a real injected arc.
+	d := graph.GraphDiff{
+		NodesAdded: []string{"before-newline\nafter-newline"},
+	}
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffDOT(&buf, d); err != nil {
+		t.Fatalf("PrintDiffDOT: %v", err)
+	}
+
+	out := buf.String()
+	// The implementation strips newlines, so "before-newline" and
+	// "after-newline" must appear on the SAME declaration line — not on
+	// separate lines where "after-newline" would look like a standalone
+	// (and potentially injected) DOT statement.
+	foundAfter := false
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue // comment lines are safe
+		}
+		// If "after-newline" appears as the first token on a non-comment line
+		// (i.e., not inside a label=... attribute), injection has occurred.
+		if strings.HasPrefix(trimmed, `"after-newline"`) {
+			t.Errorf("DOT output has 'after-newline' as a standalone line (newline not stripped): %q", line)
+		}
+		if strings.Contains(trimmed, "after-newline") {
+			foundAfter = true
+		}
+	}
+	// The name (with stripped newline) must still appear somewhere in the output.
+	if !foundAfter {
+		t.Errorf("DOT output missing 'after-newline' entirely — expected it within a label")
+	}
+}
+
+// --- PrintDiffMermaid tests ---
+
+// TestPrintDiffMermaid_Basic verifies that PrintDiffMermaid produces valid
+// Mermaid output containing the flowchart header, added/removed/persisted
+// node declarations, and style directives.
+func TestPrintDiffMermaid_Basic(t *testing.T) {
+	d := buildTestDiff(t)
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "flowchart LR") {
+		t.Errorf("expected 'flowchart LR' in Mermaid output, got:\n%s", out)
+	}
+	// Added node: evacuation-order with "(added)" label
+	if !strings.Contains(out, "added") {
+		t.Errorf("expected '(added)' label for added node in Mermaid output, got:\n%s", out)
+	}
+	// Removed node: old-model with "(removed)" label
+	if !strings.Contains(out, "removed") {
+		t.Errorf("expected '(removed)' label for removed node in Mermaid output, got:\n%s", out)
+	}
+	// Persisted node: storm-model-alpha with count label
+	if !strings.Contains(out, "storm-model-alpha") {
+		t.Errorf("expected persisted node name in Mermaid output, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffMermaid_EmptyDiff verifies that an empty GraphDiff produces
+// a valid minimal Mermaid flowchart without error.
+func TestPrintDiffMermaid_EmptyDiff(t *testing.T) {
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, graph.GraphDiff{}); err != nil {
+		t.Fatalf("PrintDiffMermaid on empty diff: unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "flowchart LR") {
+		t.Errorf("expected 'flowchart LR' even for empty diff, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffMermaid_ShadowShifts verifies that shadow shifts produce a
+// ShadowShifts subgraph block in Mermaid output with per-node style directives
+// matching the DOT color convention: emerged=green, submerged=red, reason-changed=orange.
+func TestPrintDiffMermaid_ShadowShifts(t *testing.T) {
+	d := buildDiffWithAllKinds(t)
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "subgraph ShadowShifts") {
+		t.Errorf("expected 'subgraph ShadowShifts' in Mermaid output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "end") {
+		t.Errorf("expected 'end' closing the ShadowShifts subgraph, got:\n%s", out)
+	}
+	if !strings.Contains(out, "evacuation-shelter-b") {
+		t.Errorf("expected 'evacuation-shelter-b' in ShadowShifts subgraph, got:\n%s", out)
+	}
+	// Style directives: emerged=green, submerged=red, reason-changed=orange.
+	if !strings.Contains(out, "stroke:green") {
+		t.Errorf("expected 'stroke:green' style for emerged shift, got:\n%s", out)
+	}
+	if !strings.Contains(out, "stroke:red") {
+		t.Errorf("expected 'stroke:red' style for submerged shift, got:\n%s", out)
+	}
+	if !strings.Contains(out, "stroke:orange") {
+		t.Errorf("expected 'stroke:orange' style for reason-changed shift, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffMermaid_NoShadowShifts verifies that the ShadowShifts subgraph
+// is NOT emitted when the diff has no shadow shifts.
+func TestPrintDiffMermaid_NoShadowShifts(t *testing.T) {
+	d := buildTestDiff(t)
+	d.ShadowShifts = nil
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "subgraph ShadowShifts") {
+		t.Errorf("expected NO 'subgraph ShadowShifts' for diff with no shadow shifts, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffMermaid_NodeIDSanitization verifies that node names with hyphens
+// are sanitized to underscores for Mermaid IDs, while the original names are
+// preserved as display labels.
+func TestPrintDiffMermaid_NodeIDSanitization(t *testing.T) {
+	d := graph.GraphDiff{
+		NodesAdded: []string{"storm-sensor-network"},
+	}
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	// Sanitized ID should appear (hyphens → underscores).
+	if !strings.Contains(out, "storm_sensor_network") {
+		t.Errorf("expected sanitized ID 'storm_sensor_network' in Mermaid output, got:\n%s", out)
+	}
+	// Original name should appear as the label.
+	if !strings.Contains(out, "storm-sensor-network") {
+		t.Errorf("expected original label 'storm-sensor-network' in Mermaid output, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffMermaid_AddedEdgeArrow verifies that added edges use the '-->'
+// solid arrow syntax in Mermaid output.
+func TestPrintDiffMermaid_AddedEdgeArrow(t *testing.T) {
+	d := graph.GraphDiff{
+		EdgesAdded: []graph.Edge{
+			{
+				TraceID:     "aaaaaaaa-0000-4000-8000-000000000001",
+				WhatChanged: "new connection",
+				Sources:     []string{"node-a"},
+				Targets:     []string{"node-b"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "-->") {
+		t.Errorf("expected '-->' arrow for added edge in Mermaid output, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffMermaid_RemovedEdgeArrow verifies that removed edges use the
+// '-.->'' dashed arrow syntax in Mermaid output.
+func TestPrintDiffMermaid_RemovedEdgeArrow(t *testing.T) {
+	d := graph.GraphDiff{
+		EdgesRemoved: []graph.Edge{
+			{
+				TraceID:     "aaaaaaaa-0000-4000-8000-000000000001",
+				WhatChanged: "old connection",
+				Sources:     []string{"node-a"},
+				Targets:     []string{"node-b"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "-.->") {
+		t.Errorf("expected '-.->'' dashed arrow for removed edge in Mermaid output, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffMermaid_StyleDirectives verifies that added nodes receive a
+// green stroke style directive and removed nodes receive a red dashed style.
+func TestPrintDiffMermaid_StyleDirectives(t *testing.T) {
+	d := buildTestDiff(t)
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "stroke:green") {
+		t.Errorf("expected 'stroke:green' style for added node, got:\n%s", out)
+	}
+	if !strings.Contains(out, "stroke:red") {
+		t.Errorf("expected 'stroke:red' style for removed node, got:\n%s", out)
+	}
+}
+
+// TestPrintDiffMermaid_WriteError verifies that PrintDiffMermaid propagates
+// a write error from the underlying io.Writer back to the caller.
+func TestPrintDiffMermaid_WriteError(t *testing.T) {
+	sentinel := errors.New("disk full")
+	w := errWriter{err: sentinel}
+
+	err := graph.PrintDiffMermaid(w, graph.GraphDiff{})
+	if err == nil {
+		t.Fatal("PrintDiffMermaid: expected error from failing writer, got nil")
+	}
+}
+
+// TestPrintDiffMermaid_NewlineInjection verifies that crafted node names
+// containing newlines do not inject Mermaid click directives or other
+// directives that could cause XSS in a browser renderer.
+func TestPrintDiffMermaid_NewlineInjection(t *testing.T) {
+	d := graph.GraphDiff{
+		NodesAdded: []string{"legit\nclick legit \"javascript:alert(1)\""},
+	}
+
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: %v", err)
+	}
+
+	out := buf.String()
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "click ") {
+			t.Errorf("Mermaid output contains a standalone 'click' directive: %q", line)
+		}
+	}
+}
+
+// TestPrintDiffMermaid_ShadowShiftKindInjection verifies that a crafted
+// ShadowShiftKind value cannot break out of a Mermaid label and inject
+// a click directive (XSS vector in browser-based renderers).
+func TestPrintDiffMermaid_ShadowShiftKindInjection(t *testing.T) {
+	d := graph.GraphDiff{
+		ShadowShifts: []graph.ShadowShift{
+			{
+				Name: "sensor",
+				Kind: graph.ShadowShiftKind("emerged\"\nclick sensor_id \"javascript:alert(1)\""),
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := graph.PrintDiffMermaid(&buf, d); err != nil {
+		t.Fatalf("PrintDiffMermaid: %v", err)
+	}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "click ") {
+			t.Errorf("Mermaid output contains injected click directive: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `PrintDiffDOT` and `PrintDiffMermaid` to the graph package, closing the visual export gap deferred since M8
- Visual encoding: added=green/bold, removed=red/dashed, persisted=default with count change label
- Shadow shifts rendered in dedicated subgraph with color by kind (emerged=green, submerged=red, reason-changed=orange)
- Both From and To cut metadata in output comments
- All user-derived strings sanitized against injection (node names, edge labels, ShadowShiftKind values)

## Changes

- `meshant/graph/export.go` — `PrintDiffDOT`, `PrintDiffMermaid`, `collectAllDiffNames`; package doc updated
- `meshant/graph/export_diff_test.go` — 20 new tests (DOT + Mermaid: basic, empty, shadow shifts, multi-source edges, sanitization, injection, write errors)

## Test plan

- [x] All 20 new tests pass
- [x] All existing tests pass (no regression)
- [x] `go vet ./...` clean
- [x] 98.2% graph package coverage
- [x] Security review: ShadowShiftKind injection fixed, newline stripping on all output paths
- [x] Code review: shadow shift color convention aligned with added/removed convention
- [ ] CLI wiring deferred to M10.3 (#6)

Closes #5