### PR TITLE
#7 M10.4: decision record, codemap, todo update

### DIFF
--- a/docs/CODEMAPS/meshant.md
+++ b/docs/CODEMAPS/meshant.md
@@ -75,19 +75,19 @@
 | `actor.go` | Graph-as-actor identity: `IdentifyGraph`, `IdentifyDiff`, `GraphRef`, `DiffRef`, `newUUID4`. |
 | `serial.go` | Custom JSON codec for `TimeWindow`: `MarshalJSON`, `UnmarshalJSON`. Null encoding for unbounded bounds. |
 | `reflexive.go` | Reflexive tracing: `ArticulationTrace`, `DiffTrace`. Functions that record articulation and diffing as traces. |
-| `export.go` | Export functions: `PrintGraphJSON`, `PrintDiffJSON`, `PrintGraphDOT`, `PrintGraphMermaid`. Internal helpers for DOT/Mermaid formatting. `stripNewlines()` security helper (M9) prevents injection in output from crafted trace values. |
+| `export.go` | Export functions: `PrintGraphJSON`, `PrintDiffJSON`, `PrintGraphDOT`, `PrintGraphMermaid`, `PrintDiffDOT`, `PrintDiffMermaid`. Internal helpers for DOT/Mermaid formatting. `stripNewlines()` security helper prevents injection from crafted trace values. |
 
 ### Types
 
 | Type | Key Fields | Purpose |
 |------|-----------|---------|
 | `TimeWindow` | `Start` (time.Time), `End` (time.Time) | Inclusive temporal range; zero bounds mean unbounded. |
-| `ShadowReason` | (string constant: `ShadowReasonObserver`, `ShadowReasonTimeWindow`) | Why an element is in the shadow. |
-| `ArticulationOptions` | `ObserverPositions` ([]string), `TimeWindow` (TimeWindow) | Parameters for Articulate: empty ObserverPositions = full cut. |
+| `ShadowReason` | (string constant: `ShadowReasonObserver`, `ShadowReasonTagFilter`, `ShadowReasonTimeWindow`) | Why an element is in the shadow (three reasons, sorted alphabetically). |
+| `ArticulationOptions` | `ObserverPositions` ([]string), `TimeWindow` (TimeWindow), `Tags` ([]string) | Parameters for Articulate: three cut axes. Empty = full cut on that axis. |
 | `MeshGraph` | `ID` (string, actor identity), `Nodes` (map[string]Node), `Edges` ([]Edge), `Cut` (Cut) | Articulated graph from trace dataset with observer position and shadow. |
 | `Node` | `Name` (string), `AppearanceCount` (int), `ShadowCount` (int) | Element and its visibility across included vs. shadow traces. |
 | `Edge` | `TraceID`, `WhatChanged`, `Mediation`, `Observer`, `Sources`, `Targets`, `Tags` (all []string) | One trace in the graph, preserving source context. |
-| `Cut` | `ObserverPositions`, `TimeWindow`, `TracesIncluded`, `TracesTotal`, `DistinctObserversTotal`, `ShadowElements`, `ExcludedObserverPositions` | Metadata naming the articulation position and shadow. |
+| `Cut` | `ObserverPositions`, `TimeWindow`, `Tags`, `TracesIncluded`, `TracesTotal`, `DistinctObserversTotal`, `ShadowElements`, `ExcludedObserverPositions` | Metadata naming the articulation position and shadow (three cut axes). |
 | `ShadowElement` | `Name` (string), `SeenFrom` ([]string), `Reasons` ([]ShadowReason) | Element in shadow: visible from excluded observer positions, excluded for named reasons. |
 | `GraphDiff` | `ID` (string), `NodesAdded`, `NodesRemoved` ([]string), `NodesPersisted` ([]PersistedNode), `EdgesAdded`, `EdgesRemoved` ([]Edge), `ShadowShifts` ([]ShadowShift), `From`, `To` (Cut) | Comparison of two MeshGraph articulations. |
 | `ShadowShift` | `Name`, `Kind` (ShadowShiftKind), `FromReasons`, `ToReasons` ([]ShadowReason) | Element movement across shadow boundary between two graphs (emerged, submerged, reason-changed). |
@@ -116,6 +116,8 @@
 | `PrintDiffJSON` | `func PrintDiffJSON(w io.Writer, d GraphDiff) error` | Export `GraphDiff` as JSON to io.Writer. |
 | `PrintGraphDOT` | `func PrintGraphDOT(w io.Writer, g MeshGraph) error` | Export `MeshGraph` as Graphviz DOT format. Includes node labels and edge cardinality. |
 | `PrintGraphMermaid` | `func PrintGraphMermaid(w io.Writer, g MeshGraph) error` | Export `MeshGraph` as Mermaid flowchart syntax. Sanitized IDs and truncated labels for readability. |
+| `PrintDiffDOT` | `func PrintDiffDOT(w io.Writer, d GraphDiff) error` | Export `GraphDiff` as Graphviz DOT format. Added=green/bold, removed=red/dashed, persisted with count labels, shadow shifts in cluster subgraph. |
+| `PrintDiffMermaid` | `func PrintDiffMermaid(w io.Writer, d GraphDiff) error` | Export `GraphDiff` as Mermaid flowchart. Same visual conventions as DOT diff; style directives for color coding. |
 
 ## Package: persist
 
@@ -159,8 +161,8 @@ None (persist carries no domain types; wraps graph types).
 
 | File | Contains |
 |------|----------|
-| `main.go` | CLI entry point (380 lines): subcommand dispatcher, helper types and functions. |
-| `main_test.go` | 37 tests, 92.9% coverage: all subcommands, flag parsing, error handling. |
+| `main.go` | CLI entry point: subcommand dispatcher, helper types and functions. |
+| `main_test.go` | 53 tests, 92.5% coverage: all subcommands, flag parsing, file output, error handling. |
 
 ### Types
 
@@ -180,8 +182,10 @@ None (persist carries no domain types; wraps graph types).
 | `run` | `func run(w io.Writer, args []string) error` | Command dispatcher. Parses args to identify subcommand and flags; routes to `cmdSummarize()`, `cmdValidate()`, `cmdArticulate()`, or `cmdDiff()`. |
 | `cmdSummarize` | `func cmdSummarize(w io.Writer, args []string) error` | Subcommand: Load traces, compute mesh summary, print via `loader.PrintSummary()`. Usage: `meshant summarize <file>`. |
 | `cmdValidate` | `func cmdValidate(w io.Writer, args []string) error` | Subcommand: Load and validate traces. Reports success message or errors. Usage: `meshant validate <file>`. |
-| `cmdArticulate` | `func cmdArticulate(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut with `--observer` (repeatable), `--from`, `--to` (RFC3339), `--format text\|json\|dot\|mermaid`. Applies `graph.Articulate()` and exports via `graph.PrintArticulation()` or one of the export functions. |
-| `cmdDiff` | `func cmdDiff(w io.Writer, args []string) error` | Subcommand: Load traces, articulate two cuts (`--observer-a`, `--observer-b`, per-side `--from-a`, `--to-a`, etc.), compute diff via `graph.Diff()`. `--format text\|json` (dot/mermaid not supported for diffs). |
+| `cmdArticulate` | `func cmdArticulate(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut with `--observer` (repeatable), `--tag` (repeatable, any-match), `--from`, `--to` (RFC3339), `--format text\|json\|dot\|mermaid`, `--output <file>`. |
+| `cmdDiff` | `func cmdDiff(w io.Writer, args []string) error` | Subcommand: Load traces, articulate two cuts (`--observer-a/b`, `--tag-a/b`, per-side time windows), compute diff via `graph.Diff()`. `--format text\|json\|dot\|mermaid`, `--output <file>`. |
+| `outputWriter` | `func outputWriter(w io.Writer, outputPath string) (io.Writer, error)` | Return file writer if `--output` is set, otherwise stdout. |
+| `confirmOutput` | `func confirmOutput(w io.Writer, outputPath string) error` | Print "wrote <path>" confirmation to stdout when file output is used. |
 | `usage` | `func usage()` | Print CLI usage message listing all subcommands and flags. |
 
 ### Key Design Notes
@@ -190,7 +194,8 @@ None (persist carries no domain types; wraps graph types).
 - **Testable structure**: Core logic in `run()`, `cmdSummarize()`, `cmdValidate()`, `cmdArticulate()`, `cmdDiff()`; `main()` is thin wrapper that wires os.Stdout/os.Args and exits non-zero on error
 - **Flag parsing**: Uses stdlib `flag.FlagSet` for subcommand isolation; `stringSliceFlag` enables repeatable `--observer` flags without comma-separation
 - **Time handling**: RFC3339 timestamps throughout; `parseTimeFlag()` and `parseTimeWindow()` provide clear error messages with formatting hints
-- **Format options**: `articulate` supports text/json/dot/mermaid; `diff` supports text/json only (graphs are spatial, diffs are relational)
+- **Format options**: `articulate` and `diff` both support text/json/dot/mermaid
+- **File output**: `--output <file>` writes to file instead of stdout (with deferred close for safety)
 - **Binary installation**: `go install ./cmd/meshant` produces `meshant` binary at $GOPATH/bin; used in Dockerfile at `/usr/local/bin/meshant`
 
 ## Cross-Package Relationships
@@ -285,6 +290,8 @@ cmd/demo/
 | Export diff to JSON | `graph/export.go` → `PrintDiffJSON()` |
 | Export graph to Graphviz DOT | `graph/export.go` → `PrintGraphDOT()` |
 | Export graph to Mermaid | `graph/export.go` → `PrintGraphMermaid()` |
+| Export diff to Graphviz DOT | `graph/export.go` → `PrintDiffDOT()` |
+| Export diff to Mermaid | `graph/export.go` → `PrintDiffMermaid()` |
 | Write graph to file | `persist/persist.go` → `WriteJSON()` |
 | Read graph from JSON file | `persist/persist.go` → `ReadGraphJSON()` |
 | Read diff from JSON file | `persist/persist.go` → `ReadDiffJSON()` |
@@ -357,6 +364,7 @@ cmd/demo/
 - `docs/decisions/m7-serialisation-reflexivity-v1.md` — TimeWindow JSON codec and reflexive tracing
 - `docs/decisions/structured-export-v1.md` — graph export to JSON, DOT, Mermaid formats
 - `docs/decisions/cli-v1.md` — CLI design decisions (M9)
+- `docs/decisions/m10-tag-filter-diff-export-cli-v1.md` — Tag-filter axis, diff visual export, CLI integration (M10)
 - `docs/authoring-traces.md` — Trace authoring guide with worked example (M9)
 - `docs/reviews/review_philosophical_m9.md` — Philosophical review, M9 violations and fixes
 

--- a/docs/decisions/m10-tag-filter-diff-export-cli-v1.md
+++ b/docs/decisions/m10-tag-filter-diff-export-cli-v1.md
@@ -1,0 +1,136 @@
+# M10 Decision Record — Tag-Filter Cut Axis, Diff Visual Export, CLI Integration
+
+## Context
+
+M10 closes three items deferred across earlier milestones:
+
+1. **Tag-filter cut axis** (deferred since M3) — observer-position and time-window were the
+   only cut axes. Tags were captured on traces but could not constrain an articulation.
+
+2. **GraphDiff DOT/Mermaid export** (deferred since M8) — `PrintGraphDOT` and
+   `PrintGraphMermaid` existed for `MeshGraph`, but `GraphDiff` had no visual export path.
+
+3. **CLI wiring** — the tag-filter and diff visual export needed CLI flags to be usable.
+   The user also requested file output (`--output`) to write DOT/Mermaid directly to files
+   for viewing in VS Code or other tools.
+
+---
+
+## Decision 1 — Tag filter uses any-match (OR) semantics
+
+`ArticulationOptions.Tags` filters traces to those whose `Tags` slice contains **at least
+one** of the listed tag strings (set-intersection / any-match). A trace passes if it carries
+any of the specified tags.
+
+Rationale: the tag vocabulary is open (`[]string`), and tags are descriptive categories, not
+hierarchical filters. A trace tagged `["delay", "threshold"]` should pass when the user
+asks for either `delay` or `threshold`. AND semantics (require all tags) would be overly
+restrictive for exploratory analysis — most traces carry only one or two tags.
+
+The empty tag slice means no filter (full tag cut), following the same pattern as the empty
+observer slice (full observer cut) and zero time window (full temporal cut).
+
+---
+
+## Decision 2 — Tag filter is a third shadow reason
+
+When a trace is excluded by the tag filter, all elements it mentions enter the shadow with
+reason `"tag-filter"`. This is the third `ShadowReason` alongside `"observer"` and
+`"time-window"`.
+
+Shadow reasons are accumulated per element across all excluded traces. An element can have
+multiple reasons (e.g., excluded by both observer and tag filter in different traces).
+Reasons are sorted alphabetically: `observer`, `tag-filter`, `time-window`.
+
+Rationale: the shadow must name *why* each element is invisible from this position. A
+tag-filtered shadow is fundamentally different from an observer-filtered shadow — they
+reflect different aspects of the cut's partiality.
+
+---
+
+## Decision 3 — GraphDiff DOT and Mermaid use visual conventions for delta semantics
+
+`PrintDiffDOT` and `PrintDiffMermaid` encode diff semantics through visual conventions:
+
+| Element | DOT | Mermaid |
+|---------|-----|---------|
+| Added node | green, bold | green stroke |
+| Removed node | red, dashed | red dashed stroke |
+| Persisted node | default, label "name (N→M)" | default |
+| Added edge | green arc | solid `-->` arrow |
+| Removed edge | red dashed arc | dashed `-.->` arrow |
+| Shadow shift: emerged | green | green stroke, dashed |
+| Shadow shift: submerged | red | red stroke, dashed |
+| Shadow shift: reason-changed | orange | orange stroke, dashed |
+
+Shadow shifts appear in a dedicated subgraph (`cluster_shadow_shifts` in DOT,
+`ShadowShifts` in Mermaid). The subgraph is omitted when empty.
+
+Rationale: the color conventions are consistent with the added/removed pattern used
+for nodes — green means "now visible," red means "now hidden." This makes the diagram
+self-explanatory without a legend.
+
+---
+
+## Decision 4 — Layout: top-down direction, vertical shadow stacking
+
+Both DOT and Mermaid use top-down layout (`rankdir=TB` in DOT, `flowchart TD` in Mermaid).
+DOT nodes use `shape=box` for better readability with long element names.
+
+Shadow nodes and shadow shift nodes are chained with invisible edges (DOT `style=invis`,
+Mermaid `~~~`) to force vertical stacking. Without this, Graphviz and Mermaid place all
+unconnected nodes in a subgraph on the same horizontal rank, producing very wide diagrams.
+
+Edge labels are truncated at 28 characters (reduced from 40) to keep diagrams compact.
+The JSON export remains lossless.
+
+---
+
+## Decision 5 — CLI `--tag` flag uses `stringSliceFlag` (same pattern as `--observer`)
+
+The `--tag` flag on `articulate` is repeatable, using the same `stringSliceFlag` type as
+`--observer`. Empty values (`--tag ""`) are rejected by `Set()`.
+
+For `diff`, per-side tag filters are `--tag-a` and `--tag-b`, following the established
+pattern of `--observer-a`/`--observer-b` and `--from-a`/`--to-a`.
+
+---
+
+## Decision 6 — `--output` flag writes to file; confirmation on stdout
+
+The `--output <file>` flag on both `articulate` and `diff` writes the rendered output
+(text, JSON, DOT, or Mermaid) to the specified file instead of stdout. A confirmation
+message (`wrote <path>`) is printed to stdout.
+
+The file is opened with `os.Create` and closed with a deferred `f.Close()` to prevent
+file descriptor leaks on render errors.
+
+Rationale: piping to stdout is fine for terminal use, but users working with VS Code
+extensions (Graphviz Preview, Mermaid Editor) need files they can open directly. The
+`--output` flag is simpler than requiring shell redirection (`> file.dot`) and provides
+a confirmation message.
+
+---
+
+## Decision 7 — Security: all user-derived strings sanitized in DOT/Mermaid output
+
+`ShadowShiftKind` values (typed strings that can carry arbitrary values when deserialized)
+are sanitized with `stripNewlines` (DOT) and `mermaidLabel` (Mermaid) before embedding.
+
+Tag filter values in `dotCutComment` and `PrintArticulation` are newline-stripped.
+
+This continues the M9 security convention: no user-derived string enters DOT or Mermaid
+output without sanitization.
+
+---
+
+## What M10 does not close
+
+- **CLI reflexive tracing**: the CLI does not call `ArticulationTrace`/`DiffTrace` to
+  record its own observational acts. The tools exist (M7); the CLI hasn't adopted them.
+  This is an acknowledged tension (Principle 8), not a violation.
+- **AND-semantics tag filter**: the current tag filter is OR (any-match). If a user needs
+  "traces with ALL of these tags," they would need to filter programmatically. This can be
+  revisited if use cases emerge.
+- **Interactive visualization**: DOT and Mermaid are static outputs. A live graph laboratory
+  remains a future direction.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -326,6 +326,44 @@ Library + CLI form. The framework can be used without writing Go.
 
 ---
 
+## Milestone 10: Tag-Filter Cut Axis + Diff Visual Export + CLI Integration
+
+Closes three items deferred across earlier milestones: tag-filter cut axis (deferred
+since M3), GraphDiff DOT/Mermaid export (deferred since M8), and CLI wiring for both.
+
+### Tasks
+
+- [x] **M10.1 — Tag-filter cut axis**
+  - `meshant/graph/graph.go` — `ShadowReasonTagFilter`, `Tags` on `ArticulationOptions` + `Cut`
+  - Any-match / OR semantics: trace passes if it carries any of the specified tags
+  - `meshant/graph/graph_test.go` — tag-filter groups; 100% coverage
+  - Branch: `6-m10-tag-filter-axis` (merged to develop)
+
+- [x] **M10.2 — GraphDiff DOT + Mermaid export**
+  - `meshant/graph/export.go` — `PrintDiffDOT`, `PrintDiffMermaid`
+  - Color conventions: added=green/bold, removed=red/dashed, shadow shifts color-coded
+  - Layout: `rankdir=TB` + `node [shape=box]` (DOT), `flowchart TD` (Mermaid)
+  - Invisible edge chaining for vertical shadow stacking
+  - `meshant/graph/export_diff_test.go` — diff export tests; 100% coverage
+  - Branch: `6-m10-tag-filter-axis` (merged to develop)
+
+- [x] **M10.3 — CLI integration**
+  - `--tag` repeatable flag on `articulate` (same `stringSliceFlag` pattern as `--observer`)
+  - `--tag-a`/`--tag-b` on `diff` (per-side tag filters)
+  - Unlocked `--format dot|mermaid` on `diff` (previously rejected)
+  - `--output <file>` flag on both commands (writes to file, confirmation on stdout)
+  - `outputWriter()` + `confirmOutput()` helpers; `defer f.Close()` for safety
+  - 53 CLI tests, 92.5% coverage
+  - Branch: `6-m10-tag-filter-axis` (merged to develop)
+
+- [x] **M10.4 — Decision record + codemap**
+  - `docs/decisions/m10-tag-filter-diff-export-cli-v1.md` — 7 decisions
+  - `docs/CODEMAPS/meshant.md` — updated for M10
+  - Philosophical review: 1 violation fixed (tag semantics comment), 1 tension noted (CLI reflexive tracing)
+  - Branch: `7-m10-decision-record`
+
+---
+
 ## Post-v1.0.0 — Open Horizon
 
 Informed by v1.0.0 review (`docs/reviews/release_v1_review_13-mar-26.md`) and earlier
@@ -336,8 +374,8 @@ Milestones will be cut when work begins.
 
 These deepen the analytical core — deferred across earlier milestones:
 
-- [ ] **Tag-filter cut axis** — third cut axis alongside observer and time-window (deferred since M3)
-- [ ] **GraphDiff DOT / Mermaid export** — `PrintDiffDOT`, `PrintDiffMermaid` (deferred since M8)
+- [x] **Tag-filter cut axis** — third cut axis alongside observer and time-window (completed in M10)
+- [x] **GraphDiff DOT / Mermaid export** — `PrintDiffDOT`, `PrintDiffMermaid` (completed in M10)
 - [ ] **Shadow analysis operations** — shadow summary, shadow-first mode, unstable-boundary reports
 - [ ] **Re-articulation** — re-cutting the same dataset; showing how one articulation provokes another
 


### PR DESCRIPTION
## Summary
- Created `docs/decisions/m10-tag-filter-diff-export-cli-v1.md` — 7 decisions covering tag-filter OR semantics, shadow reason, diff visual conventions, layout, CLI flags, `--output` flag, and security sanitization
- Updated `docs/CODEMAPS/meshant.md` with M10 additions (ShadowReasonTagFilter, Tags field, PrintDiffDOT/Mermaid, CLI flags, file output, test counts)
- Updated `tasks/todo.md` — added M10 milestone section, marked tag-filter and diff export as completed in post-v1.0.0 horizon

## Test plan
- [x] Decision record reads coherently and covers all M10 changes
- [x] Codemap accurately reflects current codebase state
- [x] Todo milestone section matches completed work

🤖 Generated with [Claude Code](https://claude.com/claude-code)