### PR TITLE
#51 M12.1: meshant rearticulate — critique skeleton generator

### DIFF
--- a/data/examples/cve_critique_skeleton.json
+++ b/data/examples/cve_critique_skeleton.json
@@ -1,0 +1,100 @@
+[
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "CVE-2026-44228: Authentication Bypass in fastmiddleware\n\nPublished: 2026-06-02\nCVSS 3.1 Base Score: 9.1 (Critical)\nAffected versions: fastmiddleware v1.0.0 through v1.4.2\nFixed in: v1.5.0",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000001"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "When a request includes a malformed Authorization header with a truncated JWT, the middleware falls through to the next handler without rejecting the request.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000002"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "An unauthenticated attacker can craft requests that bypass all route-level authentication checks.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000003"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "Dependabot alert #387 — storefront-api\nSeverity: critical\nPackage: github.com/example/fastmiddleware\nVulnerable: v1.3.1 (pinned in go.mod)\nPatched version: \u003e= v1.5.0",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000004"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "Picked up Dependabot #387. fastmiddleware auth bypass, CVSS 9.1. storefront-api uses this for all authenticated endpoints.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000005"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "Blast radius: every route behind AuthRequired() middleware, which is basically the entire checkout flow and account management. Customer-facing. Not theoretical — this is exploitable over the network with a crafted header.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000006"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "Holding off on a fix branch until we get sign-off on the upgrade path — v1.5.0 has a breaking change to the middleware signature so it's not a drop-in.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000007"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "Decision: Approve emergency hotfix. Risk accepted for breaking middleware signature change; regression coverage required before merge.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000008"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "semver-checker flags v1.5.0 as minor-version bump with breaking API surface — this contradicts semver contract but the security severity overrides.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-000000000009"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "CI must pass with full integration suite before deployment.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-00000000000a"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "CI status: all 847 tests passing, 0 lint violations",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-00000000000b"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "Canary: 5% traffic for 12 minutes, error rate 0.00%, p99 latency +2ms (within threshold)",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-00000000000c"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "Approver: Automated deployment gate (policy: security-critical-bypass). CI status: all 847 tests passing, 0 lint violations. Canary: 5% traffic for 12 minutes, error rate 0.00%, p99 latency +2ms (within threshold). Approved for full production rollout. 2026-06-02 17:45 UTC.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-00000000000d"
+  },
+  {
+    "timestamp": "0001-01-01T00:00:00Z",
+    "source_span": "An authentication bypass vulnerability exists in the token validation middleware of fastmiddleware.",
+    "source_doc_ref": "cve_response_raw.md",
+    "extraction_stage": "reviewed",
+    "derived_from": "d0cve001-0000-4000-8000-00000000000e"
+  }
+]

--- a/meshant/cmd/meshant/main.go
+++ b/meshant/cmd/meshant/main.go
@@ -8,6 +8,7 @@
 //   - follow:     follow a translation chain through an articulated graph
 //   - draft:      ingest LLM extraction JSON and produce TraceDraft records
 //   - promote:    promote TraceDraft records to canonical Traces
+//   - rearticulate:  produce a blank critique skeleton for each draft (M12)
 //
 // The testable logic lives in run() and each cmd* function. main() itself is
 // a thin wrapper that wires os.Stdout and os.Args, then exits non-zero on
@@ -200,6 +201,8 @@ func run(w io.Writer, args []string) error {
 		return cmdDraft(w, args[1:])
 	case "promote":
 		return cmdPromote(w, args[1:])
+	case "rearticulate":
+		return cmdRearticulate(w, args[1:])
 	default:
 		return fmt.Errorf("unknown command %q\n\n%s", args[0], usage())
 	}
@@ -836,3 +839,101 @@ func cmdPromote(w io.Writer, args []string) error {
 
 	return confirmOutput(w, outputPath)
 }
+
+// cmdRearticulate implements the "rearticulate" subcommand.
+//
+// Re-articulation is a cut, not a correction. This command reads a TraceDraft
+// JSON file and produces a skeleton JSON array: one skeleton record per draft,
+// with SourceSpan copied verbatim, DerivedFrom set to the original's ID, and
+// all content fields left blank. The critiquing agent fills in the
+// interpretation. Blank content fields are correct scaffold output — they are
+// honest abstentions, not missing data (P3 in plan_m12.md).
+//
+// Design constraints:
+//   - cmdRearticulate must NOT pre-fill content fields from the original (P3)
+//   - cmdRearticulate must NOT call Validate() on the skeleton output — the
+//     skeleton is intentionally incomplete (blank ID); Validate() would pass
+//     since source_span is present, but ID assignment is left to cmdDraft
+//   - "reviewed" is the extraction_stage for all skeletons (pipeline position,
+//     not a quality claim — Decision 7 in tracedraft-v1.md)
+//
+// Flags:
+//   - --id <id>      produce skeleton for a single draft by ID (default: all)
+//   - --output <path> write skeleton JSON to file (default: stdout)
+func cmdRearticulate(w io.Writer, args []string) error {
+	fs := flag.NewFlagSet("rearticulate", flag.ContinueOnError)
+
+	var idFilter string
+	fs.StringVar(&idFilter, "id", "", "produce skeleton for a single draft by ID")
+
+	var outputPath string
+	fs.StringVar(&outputPath, "output", "", "write skeleton JSON to file (default: stdout)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return fmt.Errorf("rearticulate: path to drafts.json required\n\nUsage: meshant rearticulate [--id <id>] [--output <file>] <drafts.json>")
+	}
+	path := remaining[0]
+
+	// Load originals. LoadDrafts assigns UUIDs and validates SourceSpan.
+	originals, err := loader.LoadDrafts(path)
+	if err != nil {
+		return fmt.Errorf("rearticulate: %w", err)
+	}
+
+	// Apply --id filter if provided.
+	if idFilter != "" {
+		var found *schema.TraceDraft
+		for i := range originals {
+			if originals[i].ID == idFilter {
+				found = &originals[i]
+				break
+			}
+		}
+		if found == nil {
+			return fmt.Errorf("rearticulate: draft with id %q not found in %s", idFilter, path)
+		}
+		originals = []schema.TraceDraft{*found}
+	}
+
+	// Build skeleton records. Each skeleton:
+	//   - copies SourceSpan verbatim (the invariant, Decision 2)
+	//   - copies SourceDocRef if present (ground truth provenance, not interpretation)
+	//   - sets DerivedFrom to the original's ID
+	//   - sets ExtractionStage to "reviewed" (pipeline position, not quality)
+	//   - leaves all content fields blank (P3: no pre-filling)
+	//   - leaves ID and ExtractedBy blank (to be assigned by meshant draft)
+	skeletons := make([]schema.TraceDraft, len(originals))
+	for i, orig := range originals {
+		skeletons[i] = schema.TraceDraft{
+			SourceSpan:      orig.SourceSpan,
+			SourceDocRef:    orig.SourceDocRef,
+			DerivedFrom:     orig.ID,
+			ExtractionStage: "reviewed",
+			// All content fields intentionally blank — the critiquing agent
+			// provides the interpretation. Blank is correct, not incomplete.
+		}
+	}
+
+	// Determine output destination: file or stdout.
+	dest, err := outputWriter(w, outputPath)
+	if err != nil {
+		return fmt.Errorf("rearticulate: %w", err)
+	}
+	if f, ok := dest.(*os.File); ok {
+		defer f.Close()
+	}
+
+	enc := json.NewEncoder(dest)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(skeletons); err != nil {
+		return fmt.Errorf("rearticulate: encode output: %w", err)
+	}
+
+	return confirmOutput(w, outputPath)
+}
+

--- a/meshant/cmd/meshant/main_test.go
+++ b/meshant/cmd/meshant/main_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/loader"
 )
 
 // --- Group 1: cmdSummarize ---
@@ -1660,3 +1662,205 @@ func TestCmdPromote_MissingArg(t *testing.T) {
 		t.Fatal("cmdPromote() with no args: want error, got nil")
 	}
 }
+
+// --- Group 14: cmdRearticulate ---
+
+// cveDraftsDatasetForRearticulate is the path to the CVE drafts fixture
+// used by Group 14 tests.
+const cveDraftsDatasetForRearticulate = "../../../data/examples/cve_response_drafts.json"
+
+// TestCmdRearticulate_ValidDraftsFile verifies that cmdRearticulate produces a
+// skeleton JSON array when given a valid drafts file. Each skeleton record must
+// have SourceSpan set (copied verbatim from original), DerivedFrom set to the
+// original's ID, and content fields (what_changed, source, target, mediation,
+// observer, tags, uncertainty_note) blank. The ID and extracted_by must also
+// be blank (to be filled by the critiquing agent). extraction_stage must be
+// "reviewed".
+func TestCmdRearticulate_ValidDraftsFile(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{cveDraftsDatasetForRearticulate})
+	if err != nil {
+		t.Fatalf("cmdRearticulate() returned unexpected error: %v", err)
+	}
+
+	var skeletons []map[string]interface{}
+	if err := json.Unmarshal([]byte(buf.String()), &skeletons); err != nil {
+		t.Fatalf("parse output JSON: %v", err)
+	}
+
+	// There should be 14 skeletons (one per original draft).
+	if len(skeletons) != 14 {
+		t.Errorf("skeleton count: got %d want 14", len(skeletons))
+	}
+
+	for i, sk := range skeletons {
+		// source_span must be set (copied verbatim).
+		span, _ := sk["source_span"].(string)
+		if span == "" {
+			t.Errorf("skeleton %d: source_span is blank; must be copied from original", i)
+		}
+
+		// derived_from must be non-empty (set to original's ID).
+		derivedFrom, _ := sk["derived_from"].(string)
+		if derivedFrom == "" {
+			t.Errorf("skeleton %d: derived_from is blank; must be original ID", i)
+		}
+
+		// extraction_stage must be "reviewed".
+		stage, _ := sk["extraction_stage"].(string)
+		if stage != "reviewed" {
+			t.Errorf("skeleton %d: extraction_stage = %q; want \"reviewed\"", i, stage)
+		}
+
+		// Content fields must be absent or blank — blank is the correct scaffold
+		// output, not a bug. P3: the scaffold must not pre-fill from original.
+		for _, field := range []string{"what_changed", "mediation", "observer", "uncertainty_note"} {
+			if v, ok := sk[field]; ok && v != "" && v != nil {
+				t.Errorf("skeleton %d: content field %q must be blank/absent; got %v", i, field, v)
+			}
+		}
+		// id and extracted_by must be blank/absent (to be assigned by meshant draft).
+		for _, field := range []string{"id", "extracted_by"} {
+			if v, ok := sk[field]; ok && v != "" && v != nil {
+				t.Errorf("skeleton %d: field %q must be blank/absent in skeleton; got %v", i, field, v)
+			}
+		}
+	}
+}
+
+// TestCmdRearticulate_IDFlag verifies that --id produces a single skeleton
+// record for that specific draft.
+func TestCmdRearticulate_IDFlag(t *testing.T) {
+	// E3's ID is the third draft in cve_response_drafts.json.
+	const e3ID = "d0cve001-0000-4000-8000-000000000003"
+
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{"--id", e3ID, cveDraftsDatasetForRearticulate})
+	if err != nil {
+		t.Fatalf("cmdRearticulate() --id returned unexpected error: %v", err)
+	}
+
+	var skeletons []map[string]interface{}
+	if err := json.Unmarshal([]byte(buf.String()), &skeletons); err != nil {
+		t.Fatalf("parse output JSON: %v", err)
+	}
+
+	if len(skeletons) != 1 {
+		t.Fatalf("--id flag: got %d skeletons; want 1", len(skeletons))
+	}
+
+	// DerivedFrom must link back to E3.
+	derivedFrom, _ := skeletons[0]["derived_from"].(string)
+	if derivedFrom != e3ID {
+		t.Errorf("skeleton derived_from = %q; want %q", derivedFrom, e3ID)
+	}
+
+	// SourceSpan must be E3's span.
+	span, _ := skeletons[0]["source_span"].(string)
+	if !strings.Contains(span, "unauthenticated attacker") {
+		t.Errorf("source_span %q does not contain E3's text", span)
+	}
+}
+
+// TestCmdRearticulate_IDFlagNotFound verifies that --id <unknown> returns an error
+// naming the unknown ID.
+func TestCmdRearticulate_IDFlagNotFound(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{"--id", "nonexistent-id-000", cveDraftsDatasetForRearticulate})
+	if err == nil {
+		t.Fatal("cmdRearticulate() with unknown --id: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent-id-000") {
+		t.Errorf("error %q does not name the unknown ID", err.Error())
+	}
+}
+
+// TestCmdRearticulate_OutputFlag verifies that --output writes the skeleton
+// JSON to a file and prints a confirmation message to stdout.
+func TestCmdRearticulate_OutputFlag(t *testing.T) {
+	outFile := filepath.Join(t.TempDir(), "skeleton.json")
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{"--output", outFile, cveDraftsDatasetForRearticulate})
+	if err != nil {
+		t.Fatalf("cmdRearticulate() --output returned unexpected error: %v", err)
+	}
+
+	// File must exist and contain valid JSON.
+	content, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	var skeletons []map[string]interface{}
+	if err := json.Unmarshal(content, &skeletons); err != nil {
+		t.Fatalf("parse output file JSON: %v", err)
+	}
+	if len(skeletons) == 0 {
+		t.Error("output file contains empty array")
+	}
+
+	// stdout must contain a confirmation message (wrote <path>).
+	stdout := buf.String()
+	if !strings.Contains(stdout, outFile) {
+		t.Errorf("stdout does not confirm output file %q; got:\n%s", outFile, stdout)
+	}
+}
+
+// TestCmdRearticulate_MissingArg verifies that cmdRearticulate returns an error
+// when called with no positional argument.
+func TestCmdRearticulate_MissingArg(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{})
+	if err == nil {
+		t.Fatal("cmdRearticulate() with no args: want error, got nil")
+	}
+}
+
+// TestCmdRearticulate_MalformedJSON verifies that cmdRearticulate returns an
+// error when the input file contains malformed JSON.
+func TestCmdRearticulate_MalformedJSON(t *testing.T) {
+	path := writeTempJSONForDraft(t, `[{not valid json}]`)
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{path})
+	if err == nil {
+		t.Fatal("cmdRearticulate() with malformed JSON: want error, got nil")
+	}
+}
+
+// TestCmdRearticulate_SkeletonRoundTrip verifies that the skeleton output can be
+// decoded by LoadDrafts (all records pass Validate) after DerivedFrom is set and
+// source_span is present. The skeleton's SourceSpan is the required field;
+// Validate() must succeed even with content fields blank.
+func TestCmdRearticulate_SkeletonRoundTrip(t *testing.T) {
+	// Generate skeleton to a temp file.
+	skeletonFile := filepath.Join(t.TempDir(), "skeleton.json")
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{"--output", skeletonFile, cveDraftsDatasetForRearticulate})
+	if err != nil {
+		t.Fatalf("cmdRearticulate() round-trip setup: %v", err)
+	}
+
+	// LoadDrafts will assign UUIDs to blank IDs and call Validate on each record.
+	// All records should pass because source_span is set and that is the only
+	// required field (Validate() in tracedraft.go).
+	drafts, err := loader.LoadDrafts(skeletonFile)
+	if err != nil {
+		t.Fatalf("LoadDrafts() on skeleton output: want nil error (source_span present), got: %v", err)
+	}
+	if len(drafts) != 14 {
+		t.Errorf("round-trip draft count: got %d want 14", len(drafts))
+	}
+	for i, d := range drafts {
+		if d.SourceSpan == "" {
+			t.Errorf("draft %d: SourceSpan empty after round-trip", i)
+		}
+		if d.DerivedFrom == "" {
+			t.Errorf("draft %d: DerivedFrom empty after round-trip", i)
+		}
+		if d.ExtractionStage != "reviewed" {
+			t.Errorf("draft %d: ExtractionStage = %q; want \"reviewed\"", i, d.ExtractionStage)
+		}
+	}
+}
+
+// --- Group 15: cmdLineage ---
+

--- a/tasks/plan_m12.md
+++ b/tasks/plan_m12.md
@@ -1,0 +1,287 @@
+# Plan: M12 — Anti-Ontology Critique Pass (Re-articulation as a Second Cut)
+
+**Date**: 2026-03-16
+**Status**: Confirmed — follows from M11 (TraceDraft + provenance-first ingestion) and brainstorm session 2026-03-16
+**Parent issue**: #50
+**Source**: `docs/tmp/brainstorm_next_2026-03-16.md`, `docs/decisions/tracedraft-v1.md`
+
+---
+
+## Problem
+
+M11 opens the ingestion mouth: `meshant draft` reads LLM-produced extraction JSON and
+produces TraceDraft records. But the path from raw material into the mesh is a one-way
+funnel: once a span is extracted, it enters the dataset as-is. The LLM's vocabulary —
+stable actors, intentions, root causes, causal chains — enters unchallenged.
+
+The CVE dataset already contains two seeded over-actorized records (E3: "attacker", E14:
+"cve-2026-44228"). These are structurally indistinguishable from well-drafted records by
+design (Decision 9 in `tracedraft-v1.md`). What is missing is a mechanism to *critically
+re-examine* them — not to correct them, but to produce an alternative reading of the same
+source span that is equally provenance-bearing and equally provisional.
+
+Widening the ingestion mouth (more source types, more templates) before this mechanism
+exists would make LLM vocabulary repatriation harder to resist at scale.
+
+---
+
+## Goal
+
+Introduce re-articulation as a first-class operation: given a TraceDraft, produce an
+alternative TraceDraft of the same SourceSpan, linked by DerivedFrom.
+
+The re-articulation is a second cut of the same material. It is:
+- Not a correction (the original is not modified)
+- Not a quality check (there is no "better" result)
+- Not automated (the critiquing agent is always external)
+
+It is another node in the DerivedFrom chain — inspectable, challengeable, itself
+provenance-bearing.
+
+---
+
+## Non-goals
+
+- Automated critique judgment or scoring
+- Live LLM calls (the boundary remains a file on disk, per tracedraft-v1.md Decision 4)
+- New TraceDraft fields (the existing schema fully supports this)
+- Structural distinction between "good" and "over-actorized" drafts (Decision 9)
+- Finalising which observer positions should produce critique drafts (future: M12.5+)
+
+---
+
+## Design principles
+
+### P1: Re-articulation is a cut, not a correction
+
+The subcommand must not frame itself as "fixing" or "improving" drafts. A critique draft
+is a parallel reading, not a verdict on the original. Both the original and the critique
+are analytical objects with equal standing in the DerivedFrom chain.
+
+### P2: SourceSpan is the invariant
+
+A re-articulation must preserve the SourceSpan verbatim. This is the ground truth anchor
+(tracedraft-v1.md Decision 2). Everything else — WhatChanged, Source, Target, Mediation,
+Observer — is the critiquing agent's interpretation and may differ freely.
+
+### P3: The scaffold's job is to set DerivedFrom, not to pre-fill content
+
+`meshant rearticulate` outputs a skeleton: SourceSpan copied, ID blank (to be assigned
+by `meshant draft`), DerivedFrom set to the original's ID, content fields blank. The
+critiquing agent fills in the interpretation. Blank content fields are correct output for
+the scaffold — they are honest abstentions, not missing data (tracedraft-v1.md Decision 3).
+
+### P4: The critique prompt template is the methodological constraint
+
+Without a documented extraction contract for the critique step, a re-articulation pass
+just produces a different draft, not necessarily an ANT-faithful one. The template
+specifies: what to preserve (SourceSpan verbatim), what to question (stable actor
+attributions, imputed intentions), what an honest abstention looks like.
+
+### P5: The lineage reader makes the chain followable
+
+Re-articulation without a lineage reader produces linked records that can only be read
+by inspecting raw JSON. A `meshant lineage` subcommand that walks DerivedFrom links
+makes the critique chain visible as a first-class CLI output.
+
+---
+
+## Phases
+
+### Phase 1 — Re-articulation scaffold (M12.1, issue #51)
+
+**File**: `meshant/cmd/meshant/main.go` (new `cmdRearticulate`)
+
+`meshant rearticulate <drafts.json>` reads a drafts file and outputs a skeleton JSON
+array: for each draft, one skeleton record with:
+- `source_span`: copied verbatim from the original
+- `derived_from`: set to the original's ID
+- `source_doc_ref`: copied if present (ground truth provenance, not interpretation)
+- All content fields (`what_changed`, `source`, `target`, `mediation`, `observer`,
+  `tags`, `uncertainty_note`): blank (P3)
+- `id`, `timestamp`: blank (to be assigned by `meshant draft`)
+- `extraction_stage`: `"reviewed"` (position in the pipeline, not a quality claim)
+- `extracted_by`: blank (to be filled by the critiquing agent)
+
+**Flags**:
+- `--id <id>` — produce skeleton for a single draft by ID (default: all drafts)
+- `--output <path>` — write skeleton JSON to file (default: stdout)
+
+**Workflow**:
+```
+meshant rearticulate cve_response_drafts.json --id <E3-id> > critique_skeleton.json
+# analyst (or LLM) fills in interpretation fields
+meshant draft critique_skeleton.json --extracted-by "human-reviewer" --stage "reviewed"
+```
+
+**Re-articulation fixture**:
+- `data/examples/cve_critique_skeleton.json` — skeleton output for E3 and E14
+- `data/examples/cve_critique_drafts.json` — filled critique drafts for E3 and E14
+  (E3: resists naming "attacker" as stable actor; E14: names "cve-2026-44228" as a
+  document, not an agent)
+
+**Tests**: `meshant/cmd/meshant/main_test.go` (Group 14)
+- Valid drafts file → skeleton output with SourceSpan + DerivedFrom set
+- `--id` flag → single skeleton only
+- `--output` flag → file written
+- Missing drafts file → error
+- Malformed JSON → error
+- Draft with no ID (edge case) → error with helpful message
+- Skeleton round-trips through `meshant draft` (loaded by LoadDrafts, passes Validate)
+
+### Phase 2 — DerivedFrom lineage reader (M12.2, issue TBD)
+
+**File**: `meshant/cmd/meshant/main.go` (new `cmdLineage`)
+
+`meshant lineage <drafts.json>` reads a drafts file and prints the DerivedFrom chains
+present in the dataset. For each chain root (a draft with no DerivedFrom), it prints
+the lineage tree: root → critique → revision → ...
+
+**Output format**:
+```
+=== DerivedFrom Chains ===
+
+[E1-id] span-harvest / llm-pass1
+  "The dependency fastmiddleware v1.3.1 is affected..."
+  └── [E3-critique-id] reviewed / human-reviewer  ← DerivedFrom E1-id
+        "fastmiddleware v1.3.1 was flagged by dependabot-bot..."
+
+Standalone drafts (no DerivedFrom, no children): 12
+```
+
+**Flags**:
+- `--id <id>` — show lineage for a single draft only
+- `--format text|json` — text (default) or JSON (for downstream processing)
+
+**Tests**: `meshant/cmd/meshant/main_test.go` (Group 15)
+- Dataset with DerivedFrom chains → chains rendered
+- Dataset with no chains → "no chains" message
+- `--id` → single chain only
+- `--format json` → JSON envelope with chain structure
+- Circular DerivedFrom reference → error (cycle detection)
+- Missing file → error
+
+### Phase 3 — Anti-ontology critique prompt template (M12.3, issue TBD)
+
+**File**: `data/prompts/critique_pass.md`
+
+Documented extraction contract for the critique step. This is the methodological
+constraint that makes re-articulation ANT-faithful rather than just "another draft."
+
+Contents:
+1. **What to preserve**: SourceSpan verbatim. Do not paraphrase. The span is the ground
+   truth anchor. Your critique is a reading of the span, not a replacement for it.
+
+2. **What to question**: Any attribution to a stable, pre-formed actor. Specifically:
+   - Named entities treated as agents with intentions ("attacker targeted...", "CVE
+     exploited...")
+   - Causal chains that imply a single responsible originator
+   - Source/target assignments where the span only shows a condition, not an act
+
+3. **What an honest abstention looks like**: If you cannot confidently name a source,
+   target, or mediation from the span alone, leave the field blank. An empty field is
+   correct — it records that the span does not support the attribution, not that the
+   attribution is missing.
+
+4. **What DerivedFrom means**: Your critique is linked to the original by DerivedFrom.
+   The original is not wrong. Your critique is a second reading. Both are analytical
+   objects. The differentiation between them is visible in the chain.
+
+5. **Worked example**: E3 original vs. E3 critique
+   - Original: `source: ["attacker"]`, `target: ["storefront-api"]`, no uncertainty_note
+   - Critique: `source: []`, `target: ["storefront-api"]`, `uncertainty_note: "The span
+     names a vulnerability class, not an attributable actor. 'Attacker' is an inference
+     from the CVE framing, not from the span itself."`
+
+**Tests**: No code tests. Fixture test: `data/examples/cve_critique_drafts.json` is
+the living proof-of-concept for this template.
+
+### Phase 4 — Decision record + codemap (M12.4, issue TBD)
+
+**File**: `docs/decisions/rearticulation-v1.md`
+
+Decisions to record:
+1. Re-articulation is a cut, not a correction (P1)
+2. SourceSpan is the invariant — the only field always preserved (P2)
+3. The scaffold produces blank content fields — blank is correct, not incomplete (P3)
+4. The critique prompt template is the methodological constraint, not the CLI (P4)
+5. DerivedFrom is positional, not genealogical — original and critique have equal standing
+6. `extraction_stage: "reviewed"` names position in the pipeline, not quality
+7. `cmdLineage` makes the critique chain a first-class CLI output — chains are not just
+   data relationships, they are the visible record of the analytical process
+8. Over-actorized records are seeded (E3, E14) and intended for critique — not as test
+   data but as methodological demonstration material
+
+Update `docs/CODEMAPS/meshant.md` and `tasks/todo.md`.
+
+---
+
+## Key design rules
+
+1. **The critique does not modify the original.** The original draft remains in the dataset
+   unchanged. The critique is a sibling, linked by DerivedFrom.
+
+2. **Blank content fields are correct scaffold output.** `meshant rearticulate` must not
+   pre-fill content fields from the original, even partially. Pre-filling would bias the
+   critique toward the original's reading.
+
+3. **The lineage reader is not a diff tool.** It shows chains, not differences between
+   chain members. Comparing original and critique is the analyst's job.
+
+4. **The critique prompt template must not frame re-articulation as improvement.** The
+   template should say "alternative reading," not "better reading" or "corrected reading."
+
+---
+
+## What M12 does NOT do
+
+- Automated critique (the critiquing agent is always external — human or LLM-via-file)
+- Live LLM calls
+- Criterion-aware critique (EquivalenceCriterion from M10.5+ is not wired into the
+  critique pass yet — this is a future milestone)
+- Multi-step chain management (the scaffold handles one re-articulation step; iterative
+  critique chains are composed manually for now)
+
+---
+
+## What this enables (future milestones, not planned here)
+
+- **Criterion-aware critique**: a re-articulation that uses an EquivalenceCriterion to
+  declare what it is preserving or questioning
+- **Critique as a trace**: the act of re-articulation recorded as a canonical Trace in
+  the mesh (following the ArticulationTrace pattern from M7)
+- **Automated critique pipeline**: `meshant critique` with live LLM — deferred to v2.0.0
+- **Inter-chain comparison**: comparing two lineage trees over the same source material
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Critique framed as "fixing" in UX or docs | Medium | Explicit P1 in all output strings and docs; "alternative reading" not "correction" |
+| SourceSpan pre-interpreted in template | Low | P2: SourceSpan is copied verbatim, never paraphrased by the scaffold |
+| Lineage reader becomes a diff tool | Low | Named explicitly as a chain reader, not a comparison tool |
+| E3/E14 fixtures treated as ground truth | Medium | Decision record explicitly states these are methodological demonstration material, not authoritative |
+
+---
+
+## Estimated scope
+
+- Phase 1 (M12.1): medium — new subcommand, 2 fixtures, ~8 tests
+- Phase 2 (M12.2): medium — new subcommand, chain-walk logic, ~8 tests
+- Phase 3 (M12.3): small — documentation + fixture, no code
+- Phase 4 (M12.4): small — docs only
+
+Total: moderate scope, high methodological weight.
+
+---
+
+## Related
+
+- `docs/decisions/tracedraft-v1.md` — Decision 2 (SourceSpan as ground truth), Decision 5
+  (DerivedFrom chain), Decision 9 (over-actorized by design)
+- `docs/directions.md` — Layer 1 work, ingestion critique before widening the mouth
+- `data/examples/cve_response_extraction.json` — E3, E14 (seeded re-articulation targets)
+- `tasks/plan_m11.md` — TraceDraft schema, ingestion contract
+- `tasks/plan_m10_5_plus.md` — EquivalenceCriterion (future: criterion-aware critique)


### PR DESCRIPTION
## Summary

- Adds `cmdRearticulate`: reads a TraceDraft JSON file, produces a skeleton JSON array with `SourceSpan` + `DerivedFrom` preserved and all content fields blank
- Adds `data/examples/cve_critique_skeleton.json` (skeleton fixture for all 14 CVE drafts)
- Adds `tasks/plan_m12.md` (full M12 plan)

## Design

Re-articulation is a **cut, not a correction**. `SourceSpan` is the invariant — the only field always preserved. Blank content fields in the skeleton are correct output (honest abstentions, not missing data). `cmdRearticulate` never pre-fills content fields from the original and never calls `Validate()` on the skeleton (which would fail since `id` is blank by design).

Workflow:
```
meshant rearticulate cve_response_drafts.json --id <E3-id> > critique_skeleton.json
# analyst fills in interpretation fields
meshant draft critique_skeleton.json --extracted-by "human-reviewer"
```

## Test plan

- [x] 8 tests in Group 14 (`TestCmdRearticulate_*`), all passing
- [x] Full test suite passes (659 tests)
- [x] `go vet` clean

## Dependencies

None. Branches directly from `develop`.

Closes #51