### PR TITLE
feat(graph): display Graph ID / Diff ID in printed output (#62)

### DIFF
--- a/meshant/graph/diff.go
+++ b/meshant/graph/diff.go
@@ -344,6 +344,14 @@ func shadowShiftLine(s ShadowShift) string {
 // Returns the first write error encountered, if any.
 func PrintDiff(w io.Writer, d GraphDiff) error {
 	lines := []string{"=== Mesh Diff (situated comparison) ===", ""}
+
+	// If this diff has been identified as an actor, print its reference so
+	// callers can cite it in subsequent traces.
+	if d.ID != "" {
+		ref, _ := DiffRef(d) // error only when ID is empty; guarded above
+		lines = append(lines, fmt.Sprintf("Diff ID: %s", ref), "")
+	}
+
 	lines = append(lines, cutSummaryLines("From", d.From)...)
 	lines = append(lines, "")
 	lines = append(lines, cutSummaryLines("To", d.To)...)

--- a/meshant/graph/diff_test.go
+++ b/meshant/graph/diff_test.go
@@ -1103,3 +1103,48 @@ func TestPrintDiff_WriteError_Propagated(t *testing.T) {
 	}
 }
 
+// TestPrintDiff_DiffID_ShownWhenIdentified verifies that an identified GraphDiff
+// prints its meshdiff:<uuid> reference at the top of the output.
+func TestPrintDiff_DiffID_ShownWhenIdentified(t *testing.T) {
+	tr := validTraceWithElements(
+		"aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeee99", "obs-a",
+		[]string{"alpha"}, []string{"beta"},
+	)
+	g1 := singleEdgeGraph(tr)
+	g2 := graph.MeshGraph{} // empty second cut
+	d := graph.IdentifyDiff(graph.Diff(g1, g2))
+	ref, err := graph.DiffRef(d)
+	if err != nil {
+		t.Fatalf("DiffRef: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := graph.PrintDiff(&buf, d); err != nil {
+		t.Fatalf("PrintDiff: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, ref) {
+		t.Errorf("output missing Diff ID %q\nGot:\n%s", ref, out)
+	}
+	if !strings.Contains(out, "Diff ID:") {
+		t.Errorf("output missing %q label\nGot:\n%s", "Diff ID:", out)
+	}
+}
+
+// TestPrintDiff_DiffID_AbsentWhenUnidentified verifies that an unidentified
+// GraphDiff does not print any "Diff ID" line.
+func TestPrintDiff_DiffID_AbsentWhenUnidentified(t *testing.T) {
+	tr := validTraceWithElements(
+		"aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeee98", "obs-a",
+		[]string{"alpha"}, []string{"beta"},
+	)
+	g1 := singleEdgeGraph(tr)
+	d := graph.Diff(g1, graph.MeshGraph{})
+	var buf bytes.Buffer
+	if err := graph.PrintDiff(&buf, d); err != nil {
+		t.Fatalf("PrintDiff: %v", err)
+	}
+	if strings.Contains(buf.String(), "Diff ID:") {
+		t.Errorf("unidentified diff should not print Diff ID line\nGot:\n%s", buf.String())
+	}
+}
+

--- a/meshant/graph/graph.go
+++ b/meshant/graph/graph.go
@@ -681,9 +681,20 @@ func PrintArticulation(w io.Writer, g MeshGraph) error {
 		fmt.Sprintf("Tag filter:           %s", tagLabel),
 		fmt.Sprintf("Traces included: %d of %d (distinct observers in full dataset: %d)",
 			g.Cut.TracesIncluded, g.Cut.TracesTotal, g.Cut.DistinctObserversTotal),
+	}
+
+	// If this graph has been identified as an actor, print its reference so
+	// callers can cite it in subsequent traces. The ID is omitted when zero
+	// (most articulations are not identified; that is the correct default).
+	if g.ID != "" {
+		ref, _ := GraphRef(g) // error only when ID is empty; guarded above
+		lines = append(lines, fmt.Sprintf("Graph ID:             %s", ref))
+	}
+
+	lines = append(lines,
 		"",
 		"Nodes (elements visible from this position):",
-	}
+	)
 	for _, ne := range nodeEntries {
 		lines = append(lines, fmt.Sprintf("  %-50s x%d", ne.name, ne.count))
 	}

--- a/meshant/graph/graph_test.go
+++ b/meshant/graph/graph_test.go
@@ -2121,3 +2121,36 @@ func TestPrintArticulation_TagFilter_ShadowReasonAnnotation(t *testing.T) {
 		t.Errorf("output missing %q annotation\nGot:\n%s", "[tag-filter]", out)
 	}
 }
+
+// TestPrintArticulation_GraphID_ShownWhenIdentified verifies that an identified
+// MeshGraph prints its meshgraph:<uuid> reference in the output header.
+func TestPrintArticulation_GraphID_ShownWhenIdentified(t *testing.T) {
+	g := graph.IdentifyGraph(newGraphForPrint())
+	ref, err := graph.GraphRef(g)
+	if err != nil {
+		t.Fatalf("GraphRef: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := graph.PrintArticulation(&buf, g); err != nil {
+		t.Fatalf("PrintArticulation: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, ref) {
+		t.Errorf("output missing Graph ID line %q\nGot:\n%s", ref, out)
+	}
+	if !strings.Contains(out, "Graph ID:") {
+		t.Errorf("output missing %q label\nGot:\n%s", "Graph ID:", out)
+	}
+}
+
+// TestPrintArticulation_GraphID_AbsentWhenUnidentified verifies that an
+// unidentified MeshGraph does not print any "Graph ID" line.
+func TestPrintArticulation_GraphID_AbsentWhenUnidentified(t *testing.T) {
+	var buf bytes.Buffer
+	if err := graph.PrintArticulation(&buf, newGraphForPrint()); err != nil {
+		t.Fatalf("PrintArticulation: %v", err)
+	}
+	if strings.Contains(buf.String(), "Graph ID:") {
+		t.Errorf("unidentified graph should not print Graph ID line\nGot:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
Closes the deferral from `graph-as-actor-v2.md` Decision 5.

## Changes

- `PrintArticulation`: prints `Graph ID: meshgraph:<uuid>` after cut metadata when `g.ID` is non-empty
- `PrintDiff`: prints `Diff ID: meshdiff:<uuid>` at top when `d.ID` is non-empty
- Both omitted for unidentified graphs/diffs (zero value = unchanged behaviour)
- 4 new tests covering identified/unidentified cases for both functions

## Why

An identified graph is an immutable mobile — it should carry its citable reference in its own printed output. Previously, calling `IdentifyGraph` then `PrintArticulation` silently discarded the ID, making it impossible for a reader of the output to cite the graph in a subsequent trace.