### PR TITLE
feat(graph,schema): IdentifyChain / ChainRef — chain-as-actor (#63)

### DIFF
--- a/meshant/graph/actor.go
+++ b/meshant/graph/actor.go
@@ -26,8 +26,9 @@ import (
 // unexported copies for use in its string-level predicates (schema.IsGraphRef etc.)
 // without creating an import cycle.
 const (
-	graphRefPrefixGraph = "meshgraph:"
-	graphRefPrefixDiff  = "meshdiff:"
+	graphRefPrefixGraph  = "meshgraph:"
+	graphRefPrefixDiff   = "meshdiff:"
+	graphRefPrefixChain  = "meshchain:"
 )
 
 // IdentifyGraph assigns a fresh, stable UUID to g.ID and returns the updated
@@ -77,6 +78,29 @@ func DiffRef(d GraphDiff) (string, error) {
 		return "", fmt.Errorf("graph.DiffRef: diff has no ID; call IdentifyDiff first")
 	}
 	return graphRefPrefixDiff + d.ID, nil
+}
+
+// IdentifyChain assigns a fresh, stable UUID to c.ID and returns the updated
+// TranslationChain. The input c is not modified (immutable pattern).
+//
+// Call IdentifyChain only when you intend to use the chain as an actor in the
+// mesh — i.e., when you plan to reference it in subsequent traces via ChainRef.
+// Most chains produced for analysis do not need to be actors.
+func IdentifyChain(c TranslationChain) TranslationChain {
+	c.ID = newUUID4()
+	return c
+}
+
+// ChainRef returns the chain-reference string for c ("meshchain:<c.ID>").
+// Returns an error if c.ID is empty — call IdentifyChain first.
+//
+// The returned string can be placed in Trace.Source or Trace.Target to record
+// that this chain acted in the mesh, consistent with generalised symmetry.
+func ChainRef(c TranslationChain) (string, error) {
+	if c.ID == "" {
+		return "", fmt.Errorf("graph.ChainRef: chain has no ID; call IdentifyChain first")
+	}
+	return graphRefPrefixChain + c.ID, nil
 }
 
 // newUUID4 generates a random version-4 UUID string in lowercase hyphenated form:

--- a/meshant/graph/actor_test.go
+++ b/meshant/graph/actor_test.go
@@ -183,3 +183,68 @@ func TestDiff_IDEmpty_ByDefault(t *testing.T) {
 		t.Errorf("Diff: d.ID = %q; want empty string", d.ID)
 	}
 }
+
+// --- IdentifyChain and ChainRef ---
+
+// TestIdentifyChain_AssignsNonEmptyID verifies that IdentifyChain sets a
+// non-empty ID on the returned chain.
+func TestIdentifyChain_AssignsNonEmptyID(t *testing.T) {
+	c := graph.IdentifyChain(graph.TranslationChain{StartElement: "x"})
+	if c.ID == "" {
+		t.Error("IdentifyChain: ID is empty; want non-empty UUID")
+	}
+}
+
+// TestIdentifyChain_DoesNotMutateInput verifies immutability: the input chain
+// is not modified by IdentifyChain.
+func TestIdentifyChain_DoesNotMutateInput(t *testing.T) {
+	original := graph.TranslationChain{StartElement: "x"}
+	_ = graph.IdentifyChain(original)
+	if original.ID != "" {
+		t.Error("IdentifyChain mutated the input chain's ID")
+	}
+}
+
+// TestIdentifyChain_IDIsUnique verifies that two calls produce different IDs.
+func TestIdentifyChain_IDIsUnique(t *testing.T) {
+	c1 := graph.IdentifyChain(graph.TranslationChain{StartElement: "x"})
+	c2 := graph.IdentifyChain(graph.TranslationChain{StartElement: "x"})
+	if c1.ID == c2.ID {
+		t.Errorf("IdentifyChain produced duplicate IDs: %q", c1.ID)
+	}
+}
+
+// TestChainRef_FormatsCorrectly verifies that ChainRef returns "meshchain:<uuid>".
+func TestChainRef_FormatsCorrectly(t *testing.T) {
+	c := graph.IdentifyChain(graph.TranslationChain{StartElement: "x"})
+	ref, err := graph.ChainRef(c)
+	if err != nil {
+		t.Fatalf("ChainRef: %v", err)
+	}
+	if !strings.HasPrefix(ref, "meshchain:") {
+		t.Errorf("ChainRef: got %q; want meshchain: prefix", ref)
+	}
+	if ref == "meshchain:" {
+		t.Errorf("ChainRef: ID portion is empty in %q", ref)
+	}
+}
+
+// TestChainRef_EmptyID_ReturnsError verifies that ChainRef returns an error
+// when the chain has not been identified.
+func TestChainRef_EmptyID_ReturnsError(t *testing.T) {
+	c := graph.TranslationChain{StartElement: "x"}
+	_, err := graph.ChainRef(c)
+	if err == nil {
+		t.Error("ChainRef: expected error for unidentified chain, got nil")
+	}
+}
+
+// TestFollowTranslation_IDEmpty_ByDefault verifies that FollowTranslation
+// returns a chain with empty ID — explicit opt-in required.
+func TestFollowTranslation_IDEmpty_ByDefault(t *testing.T) {
+	g := graph.MeshGraph{}
+	c := graph.FollowTranslation(g, "x", graph.FollowOptions{})
+	if c.ID != "" {
+		t.Errorf("FollowTranslation: c.ID = %q; want empty string", c.ID)
+	}
+}

--- a/meshant/graph/chain.go
+++ b/meshant/graph/chain.go
@@ -89,6 +89,13 @@ type TranslationChain struct {
 	// Cut is the articulation parameters of the MeshGraph this chain was
 	// read from. The chain is situated within this cut.
 	Cut Cut
+
+	// ID is the stable identifier assigned by IdentifyChain. Zero value
+	// means the chain has not been identified as an actor — it is an
+	// analytical output, not yet a participant in the mesh. Non-empty means
+	// the chain was explicitly identified and can be referenced in traces
+	// via ChainRef as "meshchain:<uuid>".
+	ID string
 }
 
 // FollowTranslation traverses connected elements through g starting from the

--- a/meshant/schema/graphref.go
+++ b/meshant/schema/graphref.go
@@ -9,6 +9,7 @@
 // The string convention (defined authoritatively in the graph package) is:
 //   - "meshgraph:<uuid>" for an identified MeshGraph
 //   - "meshdiff:<uuid>"  for an identified GraphDiff
+//   - "meshchain:<uuid>" for an identified TranslationChain
 //
 // This file provides predicate functions that let any package inspect whether a
 // source/target string is a graph-reference, without importing the graph package
@@ -23,30 +24,33 @@ import "strings"
 // The authoritative definition (which also uses these literals to produce
 // reference strings) lives in the graph package.
 const (
-	graphRefPrefixGraph = "meshgraph:"
-	graphRefPrefixDiff  = "meshdiff:"
+	graphRefPrefixGraph  = "meshgraph:"
+	graphRefPrefixDiff   = "meshdiff:"
+	graphRefPrefixChain  = "meshchain:"
 )
 
 // parseGraphRef splits a string on its first colon and checks whether the
 // part before the colon is a known graph-reference kind. Returns (kind, id)
-// where kind is "meshgraph" or "meshdiff" and id is the portion after the colon.
-// Returns ("", "") if s is not a graph-reference.
+// where kind is "meshgraph", "meshdiff", or "meshchain" and id is the portion
+// after the colon. Returns ("", "") if s is not a graph-reference.
 //
 // Using strings.Cut avoids the paired HasPrefix+TrimPrefix pattern and ensures
-// that both kind and id are extracted in a single pass.
+// that both kind and id are extracted in a single pass. Adding a new prefix
+// requires editing only this one function.
 func parseGraphRef(s string) (kind, id string) {
 	before, after, ok := strings.Cut(s, ":")
 	if !ok {
 		return "", ""
 	}
-	if before != "meshgraph" && before != "meshdiff" {
+	if before != "meshgraph" && before != "meshdiff" && before != "meshchain" {
 		return "", ""
 	}
 	return before, after
 }
 
 // IsGraphRef reports whether s is a graph-reference string — i.e., whether it
-// begins with "meshgraph:" or "meshdiff:". It does not validate the UUID portion.
+// begins with "meshgraph:", "meshdiff:", or "meshchain:". It does not validate
+// the UUID portion.
 func IsGraphRef(s string) bool {
 	kind, _ := parseGraphRef(s)
 	return kind != ""
@@ -55,6 +59,7 @@ func IsGraphRef(s string) bool {
 // GraphRefKind returns the kind prefix of a graph-reference string:
 //   - "meshgraph" if s begins with "meshgraph:"
 //   - "meshdiff"  if s begins with "meshdiff:"
+//   - "meshchain" if s begins with "meshchain:"
 //   - ""          if s is not a graph-reference
 func GraphRefKind(s string) string {
 	kind, _ := parseGraphRef(s)

--- a/meshant/schema/graphref_test.go
+++ b/meshant/schema/graphref_test.go
@@ -152,3 +152,48 @@ func TestValidate_GraphRefInTarget_Valid(t *testing.T) {
 		t.Errorf("Validate() returned error for trace with graph-ref in Target: %v", err)
 	}
 }
+
+// --- meshchain: prefix ---
+
+// TestIsGraphRef_ChainRef_True verifies that IsGraphRef recognises a
+// meshchain: reference.
+func TestIsGraphRef_ChainRef_True(t *testing.T) {
+	s := "meshchain:aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeee01"
+	if !schema.IsGraphRef(s) {
+		t.Errorf("IsGraphRef(%q) = false; want true", s)
+	}
+}
+
+// TestGraphRefKind_ChainRef verifies that GraphRefKind returns "meshchain"
+// for a meshchain: reference.
+func TestGraphRefKind_ChainRef(t *testing.T) {
+	s := "meshchain:aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeee01"
+	if got := schema.GraphRefKind(s); got != "meshchain" {
+		t.Errorf("GraphRefKind(%q) = %q; want %q", s, got, "meshchain")
+	}
+}
+
+// TestGraphRefID_ChainRef verifies that GraphRefID extracts the UUID from
+// a meshchain: reference.
+func TestGraphRefID_ChainRef(t *testing.T) {
+	id := "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeee01"
+	s := "meshchain:" + id
+	if got := schema.GraphRefID(s); got != id {
+		t.Errorf("GraphRefID(%q) = %q; want %q", s, got, id)
+	}
+}
+
+// TestValidate_ChainRefInSource_Valid confirms that Validate() accepts a trace
+// whose Source contains a meshchain: reference string.
+func TestValidate_ChainRefInSource_Valid(t *testing.T) {
+	tr := schema.Trace{
+		ID:          "c3d4e5f6-f6a7-4b8c-9d0e-f1a2b3c4d5e6",
+		Timestamp:   time.Date(2026, 3, 17, 10, 0, 0, 0, time.UTC),
+		WhatChanged: "translation chain triggered policy review",
+		Source:      []string{"meshchain:aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeee01"},
+		Observer:    "policy-agent/position-A",
+	}
+	if err := tr.Validate(); err != nil {
+		t.Errorf("Validate() returned error for trace with meshchain: in Source: %v", err)
+	}
+}


### PR DESCRIPTION
Extends generalised symmetry to translation chains. Closes the deferral from `translation-chain-v2.md`.

## Changes

- `TranslationChain.ID string` — zero value = not an actor (backward-compatible)
- `graph.IdentifyChain(c TranslationChain) TranslationChain` — assigns UUID, immutable
- `graph.ChainRef(c TranslationChain) (string, error)` — returns `"meshchain:<uuid>"`
- `graph.actor.go` — `graphRefPrefixChain = "meshchain:"` constant added
- `schema.parseGraphRef` — now recognises `"meshchain"` prefix
- `schema.IsGraphRef`, `GraphRefKind`, `GraphRefID` — handle `meshchain:` transparently
- `schema.Validate()` — accepts `meshchain:` in Source/Target (no change needed)
- 9 new tests

## Why

Chains that influence decisions should be citable in traces — the same principle that made graphs actors in M5. The M5 infrastructure was ready; this extends it to chains.