### PR TITLE
feat(schema): IntentionallyBlank on TraceDraft (#64)

### DIFF
--- a/meshant/cmd/meshant/main.go
+++ b/meshant/cmd/meshant/main.go
@@ -917,8 +917,13 @@ func cmdRearticulate(w io.Writer, args []string) error {
 			SourceDocRef:    orig.SourceDocRef,
 			DerivedFrom:     orig.ID,
 			ExtractionStage: "reviewed",
-			// All content fields intentionally blank — the critiquing agent
-			// provides the interpretation. Blank is correct, not incomplete.
+			// IntentionallyBlank declares which content fields were
+			// deliberately left empty by this cut — the critique agent
+			// provides its own interpretation. Blank is correct, not incomplete.
+			IntentionallyBlank: []string{
+				"what_changed", "source", "target",
+				"mediation", "observer", "tags",
+			},
 		}
 	}
 

--- a/meshant/cmd/meshant/main_test.go
+++ b/meshant/cmd/meshant/main_test.go
@@ -1862,6 +1862,54 @@ func TestCmdRearticulate_SkeletonRoundTrip(t *testing.T) {
 	}
 }
 
+// TestCmdRearticulate_SkeletonHasIntentionallyBlank verifies that each skeleton
+// record produced by cmdRearticulate carries an intentionally_blank array naming
+// all six content fields. This distinguishes "blank by design" from "never
+// extracted" — a critique cut, not an incomplete draft.
+func TestCmdRearticulate_SkeletonHasIntentionallyBlank(t *testing.T) {
+	var buf bytes.Buffer
+	if err := cmdRearticulate(&buf, []string{cveDraftsDatasetForRearticulate}); err != nil {
+		t.Fatalf("cmdRearticulate() returned unexpected error: %v", err)
+	}
+
+	var skeletons []map[string]interface{}
+	if err := json.Unmarshal([]byte(buf.String()), &skeletons); err != nil {
+		t.Fatalf("parse skeleton JSON: %v", err)
+	}
+
+	wantFields := []string{"what_changed", "source", "target", "mediation", "observer", "tags"}
+
+	for i, sk := range skeletons {
+		raw, ok := sk["intentionally_blank"]
+		if !ok {
+			t.Errorf("skeleton %d: intentionally_blank key absent", i)
+			continue
+		}
+		arr, ok := raw.([]interface{})
+		if !ok {
+			t.Errorf("skeleton %d: intentionally_blank is not an array; got %T", i, raw)
+			continue
+		}
+		got := make([]string, len(arr))
+		for j, v := range arr {
+			s, _ := v.(string)
+			got[j] = s
+		}
+		for _, want := range wantFields {
+			found := false
+			for _, g := range got {
+				if g == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("skeleton %d: intentionally_blank missing %q; got %v", i, want, got)
+			}
+		}
+	}
+}
+
 // --- Group 15: cmdLineage ---
 
 

--- a/meshant/loader/draftloader.go
+++ b/meshant/loader/draftloader.go
@@ -42,6 +42,13 @@ type DraftSummary struct {
 	// value for that field. This reveals which fields the ingestion pipeline
 	// is populating and which are being left empty (empty = honest abstention).
 	FieldFillRate map[string]int
+
+	// WithIntentionallyBlank is the number of drafts that declare at least
+	// one intentionally blank field — i.e., that set IntentionallyBlank on
+	// TraceDraft. These are typically critique-pass skeletons produced by
+	// meshant rearticulate, where blank content fields are correct choices,
+	// not missing data.
+	WithIntentionallyBlank int
 }
 
 // LoadDrafts reads a JSON array of TraceDraft records from path.
@@ -160,6 +167,9 @@ func SummariseDrafts(drafts []schema.TraceDraft) DraftSummary {
 		if d.DerivedFrom != "" {
 			s.FieldFillRate["derived_from"]++
 		}
+		if len(d.IntentionallyBlank) > 0 {
+			s.WithIntentionallyBlank++
+		}
 	}
 
 	return s
@@ -214,6 +224,8 @@ func PrintDraftSummary(w io.Writer, s DraftSummary) error {
 	}
 
 	lines = append(lines,
+		"",
+		fmt.Sprintf("Critique skeletons (intentionally_blank set): %d", s.WithIntentionallyBlank),
 		"",
 		"---",
 		"Note: empty fields are honest abstentions, not missing data.",

--- a/meshant/loader/draftloader_test.go
+++ b/meshant/loader/draftloader_test.go
@@ -266,3 +266,65 @@ func TestPrintDraftSummary_ContainsExpectedFields(t *testing.T) {
 		}
 	}
 }
+
+// --- WithIntentionallyBlank ---
+
+// TestSummariseDrafts_WithIntentionallyBlank_CountsCorrectly verifies that
+// SummariseDrafts counts only drafts that have a non-empty IntentionallyBlank
+// slice.
+func TestSummariseDrafts_WithIntentionallyBlank_CountsCorrectly(t *testing.T) {
+	blanked := schema.TraceDraft{
+		SourceSpan:         "span A",
+		IntentionallyBlank: []string{"what_changed", "source"},
+	}
+	notBlanked := schema.TraceDraft{SourceSpan: "span B"}
+	alsoBlanked := schema.TraceDraft{
+		SourceSpan:         "span C",
+		IntentionallyBlank: []string{"observer"},
+	}
+
+	s := loader.SummariseDrafts([]schema.TraceDraft{blanked, notBlanked, alsoBlanked})
+
+	if s.WithIntentionallyBlank != 2 {
+		t.Errorf("WithIntentionallyBlank: got %d want 2", s.WithIntentionallyBlank)
+	}
+}
+
+// TestSummariseDrafts_WithIntentionallyBlank_ZeroWhenNoneSet verifies that the
+// count is zero when no drafts set IntentionallyBlank.
+func TestSummariseDrafts_WithIntentionallyBlank_ZeroWhenNoneSet(t *testing.T) {
+	drafts := []schema.TraceDraft{
+		{SourceSpan: "a"},
+		{SourceSpan: "b"},
+	}
+	s := loader.SummariseDrafts(drafts)
+	if s.WithIntentionallyBlank != 0 {
+		t.Errorf("WithIntentionallyBlank: got %d want 0", s.WithIntentionallyBlank)
+	}
+}
+
+// TestPrintDraftSummary_ShowsIntentionallyBlankCount verifies that
+// PrintDraftSummary includes the critique-skeleton count in its output.
+func TestPrintDraftSummary_ShowsIntentionallyBlankCount(t *testing.T) {
+	s := loader.DraftSummary{
+		Total:                  4,
+		ByStage:                map[string]int{"reviewed": 2},
+		ByExtractedBy:          map[string]int{},
+		FieldFillRate:          map[string]int{"source_span": 4},
+		WithIntentionallyBlank: 2,
+	}
+
+	var buf bytes.Buffer
+	if err := loader.PrintDraftSummary(&buf, s); err != nil {
+		t.Fatalf("PrintDraftSummary: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "2") {
+		t.Errorf("output does not contain critique skeleton count '2'; output:\n%s", out)
+	}
+	// The label "intentionally_blank" or "Critique skeletons" should appear.
+	if !strings.Contains(out, "intentionally_blank") && !strings.Contains(out, "Critique skeletons") {
+		t.Errorf("output missing intentionally_blank label; output:\n%s", out)
+	}
+}

--- a/meshant/schema/tracedraft.go
+++ b/meshant/schema/tracedraft.go
@@ -90,6 +90,20 @@ type TraceDraft struct {
 	// DerivedFrom is the ID of the parent draft, linking revision records
 	// into a structurally followable chain. Empty for root drafts.
 	DerivedFrom string `json:"derived_from,omitempty"`
+
+	// IntentionallyBlank lists the names of content fields that were
+	// deliberately left empty during a critique or review pass — not because
+	// information is missing, but because the analyst decided the field
+	// should not be filled from this source span.
+	//
+	// This distinguishes "never extracted" (field absent, no entry here) from
+	// "deliberately not filled" (field absent AND name listed here). Useful
+	// for critique-pass skeletons produced by meshant rearticulate, where
+	// blank content fields are correct, not incomplete.
+	//
+	// Known field names: "what_changed", "source", "target", "mediation",
+	// "observer", "tags".
+	IntentionallyBlank []string `json:"intentionally_blank,omitempty"`
 }
 
 // Validate checks that the minimum required field is present.

--- a/meshant/schema/tracedraft_test.go
+++ b/meshant/schema/tracedraft_test.go
@@ -220,3 +220,61 @@ func TestTraceDraftChain(t *testing.T) {
 		t.Errorf("DerivedFrom: got %q want %q", child.DerivedFrom, parent.ID)
 	}
 }
+
+// --- IntentionallyBlank ---
+
+// TestTraceDraft_IntentionallyBlank_RoundTrip verifies that IntentionallyBlank
+// is preserved through struct construction and that Validate succeeds regardless
+// of whether the field is set.
+func TestTraceDraft_IntentionallyBlank_RoundTrip(t *testing.T) {
+	d := schema.TraceDraft{
+		SourceSpan:         "Raw span text.",
+		ExtractionStage:    "reviewed",
+		DerivedFrom:        "d0000000-0000-4000-8000-000000000001",
+		IntentionallyBlank: []string{"what_changed", "source", "target", "mediation", "observer", "tags"},
+	}
+
+	if err := d.Validate(); err != nil {
+		t.Fatalf("Validate() with IntentionallyBlank set: unexpected error: %v", err)
+	}
+
+	if len(d.IntentionallyBlank) != 6 {
+		t.Errorf("IntentionallyBlank length: got %d want 6", len(d.IntentionallyBlank))
+	}
+	for _, field := range []string{"what_changed", "source", "target", "mediation", "observer", "tags"} {
+		found := false
+		for _, b := range d.IntentionallyBlank {
+			if b == field {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("IntentionallyBlank missing %q", field)
+		}
+	}
+}
+
+// TestTraceDraft_IntentionallyBlank_ValidateStillRequiresSourceSpan verifies
+// that Validate still requires source_span even when IntentionallyBlank is set —
+// IntentionallyBlank does not relax the minimum invariant.
+func TestTraceDraft_IntentionallyBlank_ValidateStillRequiresSourceSpan(t *testing.T) {
+	d := schema.TraceDraft{
+		IntentionallyBlank: []string{"what_changed", "source"},
+		// SourceSpan deliberately absent.
+	}
+
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() with empty SourceSpan: want error, got nil")
+	}
+}
+
+// TestTraceDraft_IntentionallyBlank_EmptyByDefault verifies that a TraceDraft
+// created without IntentionallyBlank has a nil/empty slice — not implicitly
+// populated.
+func TestTraceDraft_IntentionallyBlank_EmptyByDefault(t *testing.T) {
+	d := schema.TraceDraft{SourceSpan: "some span"}
+	if len(d.IntentionallyBlank) != 0 {
+		t.Errorf("IntentionallyBlank: want empty by default, got %v", d.IntentionallyBlank)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `IntentionallyBlank []string` field to `TraceDraft` — distinguishes "deliberately not filled during critique" from "never extracted"
- `cmdRearticulate` now populates it with all six content field names (`what_changed`, `source`, `target`, `mediation`, `observer`, `tags`) in every skeleton
- `DraftSummary.WithIntentionallyBlank` counts drafts that carry this field
- `PrintDraftSummary` shows "Critique skeletons (intentionally_blank set): N"

## Design

Blank content fields on a rearticulate skeleton are correct, not incomplete. `IntentionallyBlank` makes that explicitness structurally visible rather than relying on a code comment.

## Test plan

- [ ] `TestTraceDraft_IntentionallyBlank_RoundTrip` — field preserved, Validate passes
- [ ] `TestTraceDraft_IntentionallyBlank_ValidateStillRequiresSourceSpan` — invariant unchanged
- [ ] `TestTraceDraft_IntentionallyBlank_EmptyByDefault` — no implicit population
- [ ] `TestSummariseDrafts_WithIntentionallyBlank_CountsCorrectly` — 2 of 3 counted
- [ ] `TestSummariseDrafts_WithIntentionallyBlank_ZeroWhenNoneSet`
- [ ] `TestPrintDraftSummary_ShowsIntentionallyBlankCount` — label appears in output
- [ ] `TestCmdRearticulate_SkeletonHasIntentionallyBlank` — all 6 fields present in JSON output

All 6 packages pass, `go vet` clean.

Closes #64