### PR TITLE
feat(loader): FollowDraftChain + ClassifyDraftChain (#68)

### DIFF
--- a/meshant/loader/draftchain.go
+++ b/meshant/loader/draftchain.go
@@ -1,0 +1,222 @@
+// draftchain.go provides derivation chain traversal and classification for
+// TraceDraft records — Layer 1 analytical operation on the ingestion pipeline.
+//
+// A derivation chain follows DerivedFrom links through a set of TraceDraft
+// records: each draft that names another as its DerivedFrom is a step in the
+// chain. This mirrors FollowTranslation in the graph package, but operates on
+// drafts rather than graph edges.
+//
+// The ingestion pipeline (span → LLM draft → critique → revision → canonical
+// trace) is itself a translation chain. FollowDraftChain makes it traversable
+// in MeshAnt's own vocabulary. ClassifyDraftChain judges each derivation step:
+// did the critique merely relay content (intermediary), transform it (mediator),
+// or shift the interpretive register and stage (translation)?
+//
+// Classification heuristics are provisional (v1) — the same disposition as
+// ClassifyChain in the graph package. Judgments are contestable.
+package loader
+
+import (
+	"github.com/automatedtomato/mesh-ant/meshant/schema"
+)
+
+// DraftStepKind is the classification of a single derivation step.
+type DraftStepKind string
+
+const (
+	// DraftIntermediary means the derivation step did not reformulate any
+	// candidate content fields. The draft relayed the source span without
+	// recorded transformation — it may have added provenance annotations
+	// (UncertaintyNote, ExtractedBy) but the interpretive content is unchanged.
+	// This is "intermediary-like", not a definitive claim.
+	DraftIntermediary DraftStepKind = "intermediary"
+
+	// DraftMediator means at least one candidate content field changed between
+	// the parent and the derived draft. The derivation step transformed the
+	// interpretation — it reformulated what_changed, source, target, mediation,
+	// observer, or tags. A mediator changes what passes through it.
+	DraftMediator DraftStepKind = "mediator"
+
+	// DraftTranslation means candidate content fields changed AND the
+	// extraction_stage changed — a regime boundary was crossed. The derivation
+	// step reformulated the interpretive frame and advanced the pipeline stage
+	// (e.g., from "weak-draft" to "reviewed").
+	DraftTranslation DraftStepKind = "translation"
+)
+
+// DraftStepClassification records the classification of one derivation step.
+// A step is the passage from chain[i-1] to chain[i].
+type DraftStepClassification struct {
+	// StepIndex is the index of the destination draft in the chain slice
+	// (i.e., the draft that was derived). StepIndex 1 means the first
+	// derivation step: from chain[0] to chain[1].
+	StepIndex int
+
+	// Kind is the classification: intermediary, mediator, or translation.
+	Kind DraftStepKind
+
+	// Reason is a human-readable justification. Always non-empty. Makes the
+	// judgment inspectable and contestable.
+	Reason string
+}
+
+// FollowDraftChain traverses DerivedFrom links through drafts starting from
+// the draft with ID from. It returns the drafts in derivation order — the root
+// draft first, then each successive derivation.
+//
+// Cycle detection is performed via a visited set: if a draft's DerivedFrom
+// points to an already-visited ID the traversal stops (the cycle-closing draft
+// is NOT included, consistent with the traversal stopping before re-entry).
+//
+// Returns an empty slice if from is not found in drafts.
+// Returns a single-element slice if the root has no derived drafts.
+func FollowDraftChain(drafts []schema.TraceDraft, from string) []schema.TraceDraft {
+	// Index drafts by ID for O(1) lookup.
+	byID := make(map[string]schema.TraceDraft, len(drafts))
+	for _, d := range drafts {
+		if d.ID != "" {
+			byID[d.ID] = d
+		}
+	}
+
+	// Build reverse index: parentID → []child to traverse forward from root.
+	// DerivedFrom is the parent link; we want to walk parent → child.
+	children := make(map[string][]string) // parentID → []childID
+	for _, d := range drafts {
+		if d.DerivedFrom != "" {
+			children[d.DerivedFrom] = append(children[d.DerivedFrom], d.ID)
+		}
+	}
+
+	root, ok := byID[from]
+	if !ok {
+		return []schema.TraceDraft{}
+	}
+
+	chain := []schema.TraceDraft{root}
+	visited := map[string]bool{from: true}
+	current := from
+
+	for {
+		kids, ok := children[current]
+		if !ok || len(kids) == 0 {
+			// No further derivations from current node.
+			break
+		}
+
+		// First-match: follow the first child by encounter order.
+		next := kids[0]
+		if visited[next] {
+			// Cycle detected — stop before re-entry.
+			break
+		}
+
+		nextDraft, ok := byID[next]
+		if !ok {
+			// Child ID references a draft not in the set — stop.
+			break
+		}
+
+		chain = append(chain, nextDraft)
+		visited[next] = true
+		current = next
+	}
+
+	return chain
+}
+
+// ClassifyDraftChain classifies each derivation step in chain. It returns one
+// DraftStepClassification per step (len(chain)-1 entries). Returns nil if
+// chain has fewer than two drafts (no steps to classify).
+//
+// v1 heuristics (provisional):
+//   - DraftTranslation: content fields changed AND extraction_stage changed
+//   - DraftMediator: content fields changed, extraction_stage unchanged
+//   - DraftIntermediary: no content fields changed
+//
+// Content fields are: what_changed, source, target, mediation, observer, tags.
+// Provenance fields (uncertainty_note, extracted_by, intentionally_blank) are
+// not content — they do not constitute mediation on their own.
+func ClassifyDraftChain(chain []schema.TraceDraft) []DraftStepClassification {
+	if len(chain) < 2 {
+		return nil
+	}
+
+	result := make([]DraftStepClassification, len(chain)-1)
+	for i := 1; i < len(chain); i++ {
+		prev := chain[i-1]
+		curr := chain[i]
+		kind, reason := classifyDraftStep(prev, curr)
+		result[i-1] = DraftStepClassification{
+			StepIndex: i,
+			Kind:      kind,
+			Reason:    reason,
+		}
+	}
+	return result
+}
+
+// classifyDraftStep applies the v1 heuristic to a single derivation step.
+func classifyDraftStep(prev, curr schema.TraceDraft) (DraftStepKind, string) {
+	content := draftContentChanged(prev, curr)
+	stage := draftStageChanged(prev, curr)
+
+	switch {
+	case content && stage:
+		return DraftTranslation,
+			"content fields reformulated and extraction_stage advanced — interpretive frame shifted"
+	case content:
+		return DraftMediator,
+			"content fields reformulated — interpretation transformed in derivation"
+	default:
+		return DraftIntermediary,
+			"no content fields changed — draft relayed without recorded transformation"
+	}
+}
+
+// draftContentChanged reports whether any candidate content field differs
+// between prev and curr. Content fields are: what_changed, source, target,
+// mediation, observer, tags. Provenance fields are excluded.
+func draftContentChanged(prev, curr schema.TraceDraft) bool {
+	if prev.WhatChanged != curr.WhatChanged {
+		return true
+	}
+	if !stringSlicesEqual(prev.Source, curr.Source) {
+		return true
+	}
+	if !stringSlicesEqual(prev.Target, curr.Target) {
+		return true
+	}
+	if prev.Mediation != curr.Mediation {
+		return true
+	}
+	if prev.Observer != curr.Observer {
+		return true
+	}
+	if !stringSlicesEqual(prev.Tags, curr.Tags) {
+		return true
+	}
+	return false
+}
+
+// draftStageChanged reports whether extraction_stage changed between prev and
+// curr. A non-empty curr.ExtractionStage that differs from prev is a stage
+// change. An empty curr.ExtractionStage is not counted as a stage change —
+// it is more likely a missing field than a deliberate advancement.
+func draftStageChanged(prev, curr schema.TraceDraft) bool {
+	return curr.ExtractionStage != "" && curr.ExtractionStage != prev.ExtractionStage
+}
+
+// stringSlicesEqual reports whether two string slices have the same length and
+// the same elements in the same order. Nil and empty are considered equal.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/meshant/loader/draftchain_test.go
+++ b/meshant/loader/draftchain_test.go
@@ -1,0 +1,233 @@
+package loader_test
+
+import (
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/loader"
+	"github.com/automatedtomato/mesh-ant/meshant/schema"
+)
+
+// --- FollowDraftChain ---
+
+// makeDraftChain builds a linear derivation chain of n drafts where each
+// draft's DerivedFrom points to the previous draft's ID.
+func makeDraftChain(n int) []schema.TraceDraft {
+	drafts := make([]schema.TraceDraft, n)
+	for i := range drafts {
+		id := string(rune('a'+i)) + "0000000-0000-4000-8000-00000000000" + string(rune('0'+i))
+		drafts[i] = schema.TraceDraft{
+			ID:              id,
+			SourceSpan:      "span",
+			ExtractionStage: "weak-draft",
+		}
+		if i > 0 {
+			drafts[i].DerivedFrom = drafts[i-1].ID
+		}
+	}
+	return drafts
+}
+
+func TestFollowDraftChain_LinearChain(t *testing.T) {
+	drafts := makeDraftChain(3)
+	chain := loader.FollowDraftChain(drafts, drafts[0].ID)
+
+	if len(chain) != 3 {
+		t.Fatalf("chain length: got %d want 3", len(chain))
+	}
+	for i, d := range chain {
+		if d.ID != drafts[i].ID {
+			t.Errorf("chain[%d].ID = %q; want %q", i, d.ID, drafts[i].ID)
+		}
+	}
+}
+
+func TestFollowDraftChain_RootNotFound(t *testing.T) {
+	drafts := makeDraftChain(2)
+	chain := loader.FollowDraftChain(drafts, "nonexistent-id")
+	if len(chain) != 0 {
+		t.Errorf("root not found: got chain len %d; want 0", len(chain))
+	}
+}
+
+func TestFollowDraftChain_SingleDraft(t *testing.T) {
+	d := schema.TraceDraft{ID: "a0000000-0000-4000-8000-000000000001", SourceSpan: "span"}
+	chain := loader.FollowDraftChain([]schema.TraceDraft{d}, d.ID)
+	if len(chain) != 1 {
+		t.Fatalf("single draft: got chain len %d; want 1", len(chain))
+	}
+	if chain[0].ID != d.ID {
+		t.Errorf("chain[0].ID = %q; want %q", chain[0].ID, d.ID)
+	}
+}
+
+func TestFollowDraftChain_CycleDetected(t *testing.T) {
+	// A → B → A (cycle): chain should stop at B, not include A again.
+	a := schema.TraceDraft{ID: "a0000000-0000-4000-8000-000000000001", SourceSpan: "span"}
+	b := schema.TraceDraft{ID: "b0000000-0000-4000-8000-000000000002", SourceSpan: "span", DerivedFrom: a.ID}
+	// Make A derive from B to close the cycle.
+	a.DerivedFrom = b.ID
+
+	chain := loader.FollowDraftChain([]schema.TraceDraft{a, b}, a.ID)
+	// Should contain A and B but stop before cycling back to A.
+	if len(chain) != 2 {
+		t.Fatalf("cycle: got chain len %d; want 2", len(chain))
+	}
+}
+
+func TestFollowDraftChain_StartsFromMiddle(t *testing.T) {
+	// A → B → C; starting from B should return [B, C].
+	drafts := makeDraftChain(3)
+	chain := loader.FollowDraftChain(drafts, drafts[1].ID)
+	if len(chain) != 2 {
+		t.Fatalf("start from middle: got chain len %d; want 2", len(chain))
+	}
+	if chain[0].ID != drafts[1].ID {
+		t.Errorf("chain[0].ID = %q; want %q", chain[0].ID, drafts[1].ID)
+	}
+}
+
+func TestFollowDraftChain_EmptyDrafts(t *testing.T) {
+	chain := loader.FollowDraftChain([]schema.TraceDraft{}, "any-id")
+	if len(chain) != 0 {
+		t.Errorf("empty drafts: got chain len %d; want 0", len(chain))
+	}
+}
+
+// --- ClassifyDraftChain ---
+
+func TestClassifyDraftChain_Intermediary(t *testing.T) {
+	// Parent and child have identical content fields; only UncertaintyNote differs.
+	parent := schema.TraceDraft{
+		ID:              "a0000000-0000-4000-8000-000000000001",
+		SourceSpan:      "span",
+		WhatChanged:     "something happened",
+		Observer:        "analyst",
+		ExtractionStage: "weak-draft",
+	}
+	child := schema.TraceDraft{
+		ID:              "b0000000-0000-4000-8000-000000000002",
+		SourceSpan:      "span",
+		WhatChanged:     "something happened", // unchanged
+		Observer:        "analyst",            // unchanged
+		ExtractionStage: "weak-draft",         // unchanged
+		UncertaintyNote: "source unclear",     // provenance only
+		DerivedFrom:     parent.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{parent, child})
+	if len(classifications) != 1 {
+		t.Fatalf("classification count: got %d; want 1", len(classifications))
+	}
+	if classifications[0].Kind != loader.DraftIntermediary {
+		t.Errorf("kind: got %q; want %q", classifications[0].Kind, loader.DraftIntermediary)
+	}
+}
+
+func TestClassifyDraftChain_Mediator(t *testing.T) {
+	// Child reformulates WhatChanged but keeps the same ExtractionStage.
+	parent := schema.TraceDraft{
+		ID:              "a0000000-0000-4000-8000-000000000001",
+		SourceSpan:      "span",
+		WhatChanged:     "original framing",
+		ExtractionStage: "weak-draft",
+	}
+	child := schema.TraceDraft{
+		ID:              "b0000000-0000-4000-8000-000000000002",
+		SourceSpan:      "span",
+		WhatChanged:     "reformulated framing", // content changed
+		ExtractionStage: "weak-draft",           // stage unchanged
+		DerivedFrom:     parent.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{parent, child})
+	if len(classifications) != 1 {
+		t.Fatalf("classification count: got %d; want 1", len(classifications))
+	}
+	if classifications[0].Kind != loader.DraftMediator {
+		t.Errorf("kind: got %q; want %q", classifications[0].Kind, loader.DraftMediator)
+	}
+}
+
+func TestClassifyDraftChain_Translation(t *testing.T) {
+	// Child reformulates WhatChanged AND advances ExtractionStage.
+	parent := schema.TraceDraft{
+		ID:              "a0000000-0000-4000-8000-000000000001",
+		SourceSpan:      "span",
+		WhatChanged:     "original framing",
+		ExtractionStage: "weak-draft",
+	}
+	child := schema.TraceDraft{
+		ID:              "b0000000-0000-4000-8000-000000000002",
+		SourceSpan:      "span",
+		WhatChanged:     "reformulated framing", // content changed
+		ExtractionStage: "reviewed",             // stage advanced
+		DerivedFrom:     parent.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{parent, child})
+	if len(classifications) != 1 {
+		t.Fatalf("classification count: got %d; want 1", len(classifications))
+	}
+	if classifications[0].Kind != loader.DraftTranslation {
+		t.Errorf("kind: got %q; want %q", classifications[0].Kind, loader.DraftTranslation)
+	}
+}
+
+func TestClassifyDraftChain_NilForSingleDraft(t *testing.T) {
+	d := schema.TraceDraft{ID: "a0000000-0000-4000-8000-000000000001", SourceSpan: "span"}
+	result := loader.ClassifyDraftChain([]schema.TraceDraft{d})
+	if result != nil {
+		t.Errorf("single draft: want nil, got %v", result)
+	}
+}
+
+func TestClassifyDraftChain_MultiStep(t *testing.T) {
+	// Three drafts: A→B (intermediary), B→C (mediator).
+	a := schema.TraceDraft{
+		ID: "a0000000-0000-4000-8000-000000000001", SourceSpan: "span",
+		WhatChanged: "original", ExtractionStage: "weak-draft",
+	}
+	b := schema.TraceDraft{
+		ID: "b0000000-0000-4000-8000-000000000002", SourceSpan: "span",
+		WhatChanged: "original", ExtractionStage: "weak-draft", // same content
+		UncertaintyNote: "note added", DerivedFrom: a.ID,
+	}
+	c := schema.TraceDraft{
+		ID: "c0000000-0000-4000-8000-000000000003", SourceSpan: "span",
+		WhatChanged: "reformulated", ExtractionStage: "weak-draft", // content changed
+		DerivedFrom: b.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{a, b, c})
+	if len(classifications) != 2 {
+		t.Fatalf("multi-step: got %d classifications; want 2", len(classifications))
+	}
+	if classifications[0].Kind != loader.DraftIntermediary {
+		t.Errorf("step 0: got %q; want %q", classifications[0].Kind, loader.DraftIntermediary)
+	}
+	if classifications[1].Kind != loader.DraftMediator {
+		t.Errorf("step 1: got %q; want %q", classifications[1].Kind, loader.DraftMediator)
+	}
+}
+
+func TestClassifyDraftChain_StepIndexIsCorrect(t *testing.T) {
+	drafts := makeDraftChain(3)
+	classifications := loader.ClassifyDraftChain(drafts)
+	for i, c := range classifications {
+		want := i + 1
+		if c.StepIndex != want {
+			t.Errorf("classifications[%d].StepIndex = %d; want %d", i, c.StepIndex, want)
+		}
+	}
+}
+
+func TestClassifyDraftChain_ReasonNonEmpty(t *testing.T) {
+	drafts := makeDraftChain(2)
+	classifications := loader.ClassifyDraftChain(drafts)
+	if len(classifications) == 0 {
+		t.Fatal("no classifications returned")
+	}
+	if classifications[0].Reason == "" {
+		t.Error("Reason is empty; must be non-empty for inspectability")
+	}
+}


### PR DESCRIPTION
## Summary

- `FollowDraftChain(drafts, from)` traverses `DerivedFrom` links in derivation order — mirrors `FollowTranslation` for the ingestion pipeline
- `ClassifyDraftChain(chain)` classifies each step: `intermediary` (content unchanged), `mediator` (content reformulated), `translation` (content reformulated + stage advanced)
- Cycle detection via visited set; first-match on multiple children
- 11 tests covering linear chains, root-not-found, cycle detection, all three step kinds, multi-step, StepIndex correctness, Reason non-empty

## ANT grounding

The derivation chain is a translation chain. Making it traversable in MeshAnt's vocabulary closes the gap between the ingestion apparatus and the analytical apparatus (Principle 8 — the framework observes its own action in the mesh).

Closes #68