### PR TITLE
feat(schema,loader,cmd): CriterionRef on TraceDraft (#69)

### DIFF
--- a/meshant/cmd/meshant/main.go
+++ b/meshant/cmd/meshant/main.go
@@ -861,8 +861,10 @@ func cmdPromote(w io.Writer, args []string) error {
 //     not a quality claim — Decision 7 in tracedraft-v1.md)
 //
 // Flags:
-//   - --id <id>      produce skeleton for a single draft by ID (default: all)
-//   - --output <path> write skeleton JSON to file (default: stdout)
+//   - --id <id>             produce skeleton for a single draft by ID (default: all)
+//   - --output <path>       write skeleton JSON to file (default: stdout)
+//   - --criterion-file <path> load an EquivalenceCriterion and set its Name as
+//     CriterionRef on each skeleton, making the critique pass self-situated
 func cmdRearticulate(w io.Writer, args []string) error {
 	fs := flag.NewFlagSet("rearticulate", flag.ContinueOnError)
 
@@ -871,6 +873,9 @@ func cmdRearticulate(w io.Writer, args []string) error {
 
 	var outputPath string
 	fs.StringVar(&outputPath, "output", "", "write skeleton JSON to file (default: stdout)")
+
+	var criterionFile string
+	fs.StringVar(&criterionFile, "criterion-file", "", "path to EquivalenceCriterion JSON; sets criterion_ref on each skeleton")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -903,6 +908,16 @@ func cmdRearticulate(w io.Writer, args []string) error {
 		originals = []schema.TraceDraft{*found}
 	}
 
+	// Load criterion if provided. criterionName is empty when no flag was given.
+	var criterionName string
+	if criterionFile != "" {
+		c, err := loadCriterionFile(criterionFile)
+		if err != nil {
+			return fmt.Errorf("rearticulate: %w", err)
+		}
+		criterionName = c.Name
+	}
+
 	// Build skeleton records. Each skeleton:
 	//   - copies SourceSpan verbatim (the invariant, Decision 2)
 	//   - copies SourceDocRef if present (ground truth provenance, not interpretation)
@@ -910,6 +925,7 @@ func cmdRearticulate(w io.Writer, args []string) error {
 	//   - sets ExtractionStage to "reviewed" (pipeline position, not quality)
 	//   - leaves all content fields blank (P3: no pre-filling)
 	//   - leaves ID and ExtractedBy blank (to be assigned by meshant draft)
+	//   - sets CriterionRef when --criterion-file was provided (self-situated skeleton)
 	skeletons := make([]schema.TraceDraft, len(originals))
 	for i, orig := range originals {
 		skeletons[i] = schema.TraceDraft{
@@ -917,6 +933,7 @@ func cmdRearticulate(w io.Writer, args []string) error {
 			SourceDocRef:    orig.SourceDocRef,
 			DerivedFrom:     orig.ID,
 			ExtractionStage: "reviewed",
+			CriterionRef:    criterionName,
 			// IntentionallyBlank declares which content fields were
 			// deliberately left empty by this cut — the critique agent
 			// provides its own interpretation. Blank is correct, not incomplete.

--- a/meshant/cmd/meshant/main_test.go
+++ b/meshant/cmd/meshant/main_test.go
@@ -1910,6 +1910,62 @@ func TestCmdRearticulate_SkeletonHasIntentionallyBlank(t *testing.T) {
 	}
 }
 
+// TestCmdRearticulate_CriterionFileSetsCriterionRef verifies that --criterion-file
+// populates criterion_ref on every skeleton with the criterion's Name field.
+func TestCmdRearticulate_CriterionFileSetsCriterionRef(t *testing.T) {
+	// Write a minimal criterion file.
+	criterionJSON := `{"name":"actor-stability-v1","declaration":"Only juridical–scientific crossings count"}`
+	criterionPath := writeTempJSONForDraft(t, criterionJSON)
+
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{"--criterion-file", criterionPath, cveDraftsDatasetForRearticulate})
+	if err != nil {
+		t.Fatalf("cmdRearticulate() --criterion-file returned error: %v", err)
+	}
+
+	var skeletons []map[string]interface{}
+	if err := json.Unmarshal([]byte(buf.String()), &skeletons); err != nil {
+		t.Fatalf("parse skeleton JSON: %v", err)
+	}
+
+	for i, sk := range skeletons {
+		ref, _ := sk["criterion_ref"].(string)
+		if ref != "actor-stability-v1" {
+			t.Errorf("skeleton %d: criterion_ref = %q; want %q", i, ref, "actor-stability-v1")
+		}
+	}
+}
+
+// TestCmdRearticulate_CriterionFileAbsent_NoCriterionRef verifies that when
+// --criterion-file is not provided, criterion_ref is absent from skeletons.
+func TestCmdRearticulate_CriterionFileAbsent_NoCriterionRef(t *testing.T) {
+	var buf bytes.Buffer
+	if err := cmdRearticulate(&buf, []string{cveDraftsDatasetForRearticulate}); err != nil {
+		t.Fatalf("cmdRearticulate() returned error: %v", err)
+	}
+
+	var skeletons []map[string]interface{}
+	if err := json.Unmarshal([]byte(buf.String()), &skeletons); err != nil {
+		t.Fatalf("parse skeleton JSON: %v", err)
+	}
+
+	for i, sk := range skeletons {
+		if v, ok := sk["criterion_ref"]; ok && v != "" && v != nil {
+			t.Errorf("skeleton %d: criterion_ref should be absent; got %v", i, v)
+		}
+	}
+}
+
+// TestCmdRearticulate_CriterionFileBadPath verifies that a non-existent
+// --criterion-file path returns an error.
+func TestCmdRearticulate_CriterionFileBadPath(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdRearticulate(&buf, []string{"--criterion-file", "/nonexistent/criterion.json", cveDraftsDatasetForRearticulate})
+	if err == nil {
+		t.Fatal("expected error for bad criterion-file path, got nil")
+	}
+}
+
 // --- Group 15: cmdLineage ---
 
 

--- a/meshant/loader/draftloader.go
+++ b/meshant/loader/draftloader.go
@@ -49,6 +49,12 @@ type DraftSummary struct {
 	// meshant rearticulate, where blank content fields are correct choices,
 	// not missing data.
 	WithIntentionallyBlank int
+
+	// WithCriterionRef is the number of drafts that carry a non-empty
+	// CriterionRef — i.e., that declare the EquivalenceCriterion under which
+	// they were produced. A non-zero count means some skeletons are self-situated:
+	// their interpretive frame is named, not implicit.
+	WithCriterionRef int
 }
 
 // LoadDrafts reads a JSON array of TraceDraft records from path.
@@ -170,6 +176,9 @@ func SummariseDrafts(drafts []schema.TraceDraft) DraftSummary {
 		if len(d.IntentionallyBlank) > 0 {
 			s.WithIntentionallyBlank++
 		}
+		if d.CriterionRef != "" {
+			s.WithCriterionRef++
+		}
 	}
 
 	return s
@@ -226,6 +235,7 @@ func PrintDraftSummary(w io.Writer, s DraftSummary) error {
 	lines = append(lines,
 		"",
 		fmt.Sprintf("Critique skeletons (intentionally_blank set): %d", s.WithIntentionallyBlank),
+		fmt.Sprintf("Self-situated skeletons (criterion_ref set):  %d", s.WithCriterionRef),
 		"",
 		"---",
 		"Note: empty fields are honest abstentions, not missing data.",

--- a/meshant/loader/draftloader_test.go
+++ b/meshant/loader/draftloader_test.go
@@ -328,3 +328,44 @@ func TestPrintDraftSummary_ShowsIntentionallyBlankCount(t *testing.T) {
 		t.Errorf("output missing intentionally_blank label; output:\n%s", out)
 	}
 }
+
+// --- WithCriterionRef ---
+
+func TestSummariseDrafts_WithCriterionRef_CountsCorrectly(t *testing.T) {
+	withRef := schema.TraceDraft{SourceSpan: "a", CriterionRef: "actor-stability-v1"}
+	withoutRef := schema.TraceDraft{SourceSpan: "b"}
+	alsoWithRef := schema.TraceDraft{SourceSpan: "c", CriterionRef: "actor-stability-v1"}
+
+	s := loader.SummariseDrafts([]schema.TraceDraft{withRef, withoutRef, alsoWithRef})
+	if s.WithCriterionRef != 2 {
+		t.Errorf("WithCriterionRef: got %d want 2", s.WithCriterionRef)
+	}
+}
+
+func TestSummariseDrafts_WithCriterionRef_ZeroWhenNoneSet(t *testing.T) {
+	s := loader.SummariseDrafts([]schema.TraceDraft{
+		{SourceSpan: "a"},
+		{SourceSpan: "b"},
+	})
+	if s.WithCriterionRef != 0 {
+		t.Errorf("WithCriterionRef: got %d want 0", s.WithCriterionRef)
+	}
+}
+
+func TestPrintDraftSummary_ShowsCriterionRefCount(t *testing.T) {
+	s := loader.DraftSummary{
+		Total:            3,
+		ByStage:          map[string]int{},
+		ByExtractedBy:    map[string]int{},
+		FieldFillRate:    map[string]int{"source_span": 3},
+		WithCriterionRef: 2,
+	}
+	var buf bytes.Buffer
+	if err := loader.PrintDraftSummary(&buf, s); err != nil {
+		t.Fatalf("PrintDraftSummary: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "criterion_ref") && !strings.Contains(out, "Self-situated") {
+		t.Errorf("output missing criterion_ref label; output:\n%s", out)
+	}
+}

--- a/meshant/schema/tracedraft.go
+++ b/meshant/schema/tracedraft.go
@@ -91,6 +91,19 @@ type TraceDraft struct {
 	// into a structurally followable chain. Empty for root drafts.
 	DerivedFrom string `json:"derived_from,omitempty"`
 
+	// CriterionRef is the name of the EquivalenceCriterion under which this
+	// draft was produced or reviewed. Set by meshant rearticulate --criterion-file
+	// to record the interpretive frame that governed the critique pass.
+	//
+	// CriterionRef stores the criterion's Name string — a citation, not a copy.
+	// The criterion file remains the authoritative source; CriterionRef names it
+	// so that the skeleton is self-situated: you know not just that fields were
+	// left blank, but under what interpretive conditions.
+	//
+	// Empty means no criterion was declared. Does not affect Validate(),
+	// IsPromotable(), or Promote().
+	CriterionRef string `json:"criterion_ref,omitempty"`
+
 	// IntentionallyBlank lists the names of content fields that were
 	// deliberately left empty during a critique or review pass — not because
 	// information is missing, but because the analyst decided the field

--- a/meshant/schema/tracedraft_test.go
+++ b/meshant/schema/tracedraft_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -276,5 +277,55 @@ func TestTraceDraft_IntentionallyBlank_EmptyByDefault(t *testing.T) {
 	d := schema.TraceDraft{SourceSpan: "some span"}
 	if len(d.IntentionallyBlank) != 0 {
 		t.Errorf("IntentionallyBlank: want empty by default, got %v", d.IntentionallyBlank)
+	}
+}
+
+// --- CriterionRef ---
+
+func TestTraceDraft_CriterionRef_EmptyByDefault(t *testing.T) {
+	d := schema.TraceDraft{SourceSpan: "span"}
+	if d.CriterionRef != "" {
+		t.Errorf("CriterionRef: want empty by default, got %q", d.CriterionRef)
+	}
+}
+
+func TestTraceDraft_CriterionRef_ValidateStillRequiresSourceSpan(t *testing.T) {
+	d := schema.TraceDraft{CriterionRef: "my-criterion"}
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() with CriterionRef but no SourceSpan: want error, got nil")
+	}
+}
+
+func TestTraceDraft_CriterionRef_DoesNotAffectIsPromotable(t *testing.T) {
+	// A draft with CriterionRef but missing WhatChanged/Observer is not promotable.
+	d := schema.TraceDraft{
+		ID:           "a0000000-0000-4000-8000-000000000001",
+		SourceSpan:   "span",
+		CriterionRef: "my-criterion",
+	}
+	if d.IsPromotable() {
+		t.Error("IsPromotable(): want false (WhatChanged and Observer missing), got true")
+	}
+}
+
+func TestTraceDraft_CriterionRef_OmitEmptyInJSON(t *testing.T) {
+	d := schema.TraceDraft{SourceSpan: "span"}
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(b), "criterion_ref") {
+		t.Errorf("criterion_ref should be omitted when empty; JSON: %s", b)
+	}
+}
+
+func TestTraceDraft_CriterionRef_PresentInJSON(t *testing.T) {
+	d := schema.TraceDraft{SourceSpan: "span", CriterionRef: "actor-stability-v1"}
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"criterion_ref":"actor-stability-v1"`) {
+		t.Errorf("criterion_ref missing from JSON: %s", b)
 	}
 }


### PR DESCRIPTION
## Summary

- `CriterionRef string` added to `TraceDraft` (`json:"criterion_ref,omitempty"`) — names the `EquivalenceCriterion` used during a critique pass
- `cmdRearticulate --criterion-file <path>` loads the criterion and stamps its `Name` on every skeleton
- `DraftSummary.WithCriterionRef` counts drafts carrying the field; `PrintDraftSummary` reports it as "Self-situated skeletons (criterion_ref set)"
- Does not affect `Validate()`, `IsPromotable()`, or `Promote()`

## Design

`CriterionRef` stores the criterion's `Name` string — a citation, not a copy. The skeleton knows under what interpretive conditions it was generated. Reuses `loadCriterionFile()` already implemented in `cmdFollow`.

## Test plan

- [ ] `CriterionRef` empty by default, omitted from JSON when empty
- [ ] `Validate()` still requires `SourceSpan`; `IsPromotable()` unaffected
- [ ] `WithCriterionRef` counts correctly in `SummariseDrafts`
- [ ] `PrintDraftSummary` contains label
- [ ] `cmdRearticulate --criterion-file` sets `criterion_ref` on all skeletons
- [ ] Without `--criterion-file`, `criterion_ref` absent from output
- [ ] Bad path returns error

Closes #69