### PR TITLE
feat(graph): SummariseShadow + PrintShadowSummary (#13)

### DIFF
--- a/meshant/graph/shadow.go
+++ b/meshant/graph/shadow.go
@@ -1,0 +1,185 @@
+// shadow.go provides shadow analysis operations — interrogating what the cut
+// excludes as a first-class analytical object.
+//
+// A shadow is not missing data. It is the structured record of what this
+// articulation cannot see: elements present in the full dataset that fall
+// outside the chosen cut. SummariseShadow makes the shadow legible without
+// treating it as a deficiency.
+//
+// The operations here read data already present on MeshGraph.Cut — no new
+// analysis is needed. SummariseShadow reorganises that data into a form
+// oriented toward the shadow rather than toward what is visible.
+package graph
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// ShadowSummary is a provenance-aware reading of the shadow of a MeshGraph.
+// It reorganises Cut.ShadowElements for shadow-first analysis: how many
+// elements are excluded, for what reasons, and from which observer positions
+// the shadow would lift.
+type ShadowSummary struct {
+	// TotalShadowed is the number of elements in the shadow.
+	TotalShadowed int
+
+	// ByReason maps each ShadowReason string to the count of shadow elements
+	// that carry that reason. An element that was excluded for multiple reasons
+	// is counted once per reason.
+	ByReason map[string]int
+
+	// Elements is the full list of shadow elements, in the same order as
+	// Cut.ShadowElements (alphabetical by name).
+	Elements []ShadowElement
+
+	// SeenFromCounts maps observer strings to the number of shadow elements
+	// for which that observer appears in SeenFrom. This answers: "from which
+	// position would the most shadow lift?" Observers with high counts are the
+	// positions that see the most of what this cut excludes.
+	SeenFromCounts map[string]int
+
+	// Cut is the articulation parameters that produced this shadow. Retained
+	// so the summary is self-situated — a shadow report without its cut is
+	// uninterpretable.
+	Cut Cut
+}
+
+// SummariseShadow reads the shadow of g and returns a ShadowSummary.
+// It does not re-articulate — it operates on data already present in g.Cut.
+// The returned summary is immutable; slices are copied from the MeshGraph.
+func SummariseShadow(g MeshGraph) ShadowSummary {
+	s := ShadowSummary{
+		TotalShadowed:  len(g.Cut.ShadowElements),
+		ByReason:       make(map[string]int),
+		SeenFromCounts: make(map[string]int),
+		Cut:            g.Cut,
+	}
+
+	// Copy elements to decouple the summary from the source graph.
+	s.Elements = make([]ShadowElement, len(g.Cut.ShadowElements))
+	copy(s.Elements, g.Cut.ShadowElements)
+
+	for _, elem := range g.Cut.ShadowElements {
+		// Count by each reason (an element with multiple reasons is counted
+		// once per reason — consistent with ANT: multiple causes can coexist).
+		for _, r := range elem.Reasons {
+			s.ByReason[string(r)]++
+		}
+		// Count how often each observer appears in SeenFrom.
+		for _, obs := range elem.SeenFrom {
+			s.SeenFromCounts[obs]++
+		}
+	}
+
+	return s
+}
+
+// PrintShadowSummary writes a shadow analysis report to w.
+// The report is oriented toward what the cut excludes: how many elements,
+// why they were excluded, and which positions see what this cut cannot.
+//
+// Returns the first write error encountered, if any.
+func PrintShadowSummary(w io.Writer, s ShadowSummary) error {
+	lines := []string{
+		"=== Shadow Summary ===",
+		"",
+	}
+
+	// Cut context.
+	if len(s.Cut.ObserverPositions) > 0 {
+		lines = append(lines, fmt.Sprintf("Observer:    %s", joinStrings(s.Cut.ObserverPositions, ", ")))
+	} else {
+		lines = append(lines, "Observer:    (full cut — all positions)")
+	}
+	lines = append(lines,
+		fmt.Sprintf("Traces:      %d included of %d total", s.Cut.TracesIncluded, s.Cut.TracesTotal),
+		"",
+		fmt.Sprintf("Shadow elements: %d", s.TotalShadowed),
+	)
+
+	if s.TotalShadowed == 0 {
+		lines = append(lines,
+			"",
+			"No shadow — this cut includes all elements in the dataset.",
+			"",
+			"---",
+			"Note: shadow is a cut decision, not missing data.",
+		)
+		return writeLines(w, lines)
+	}
+
+	// Breakdown by reason.
+	lines = append(lines, "", "By exclusion reason:")
+	reasons := []string{"observer", "tag-filter", "time-window"}
+	for _, r := range reasons {
+		if n, ok := s.ByReason[r]; ok {
+			lines = append(lines, fmt.Sprintf("  %-20s %d", r, n))
+		}
+	}
+
+	// Observer coverage of the shadow: who sees what this cut cannot.
+	if len(s.SeenFromCounts) > 0 {
+		lines = append(lines, "", "Shadow visible from (observer positions that un-shadow elements):")
+		// Sort observers by descending count, then alphabetically for ties.
+		type obsCount struct {
+			obs   string
+			count int
+		}
+		ordered := make([]obsCount, 0, len(s.SeenFromCounts))
+		for obs, n := range s.SeenFromCounts {
+			ordered = append(ordered, obsCount{obs, n})
+		}
+		sort.Slice(ordered, func(i, j int) bool {
+			if ordered[i].count != ordered[j].count {
+				return ordered[i].count > ordered[j].count
+			}
+			return ordered[i].obs < ordered[j].obs
+		})
+		for _, oc := range ordered {
+			lines = append(lines, fmt.Sprintf("  %-30s %d element(s)", oc.obs, oc.count))
+		}
+	}
+
+	// List all shadow elements with their reasons.
+	lines = append(lines, "", "Shadow elements:")
+	for _, elem := range s.Elements {
+		reasonStrs := make([]string, len(elem.Reasons))
+		for i, r := range elem.Reasons {
+			reasonStrs[i] = string(r)
+		}
+		lines = append(lines, fmt.Sprintf("  %-30s [%s]", elem.Name, joinStrings(reasonStrs, ", ")))
+	}
+
+	lines = append(lines,
+		"",
+		"---",
+		"Note: shadow is a cut decision, not missing data.",
+		"Each excluded element names what this position cannot see from where it stands.",
+	)
+
+	return writeLines(w, lines)
+}
+
+// writeLines writes each line followed by a newline to w.
+func writeLines(w io.Writer, lines []string) error {
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("graph: PrintShadowSummary: %w", err)
+		}
+	}
+	return nil
+}
+
+// joinStrings concatenates ss with sep. Returns "(none)" for empty slices.
+func joinStrings(ss []string, sep string) string {
+	if len(ss) == 0 {
+		return "(none)"
+	}
+	result := ss[0]
+	for _, s := range ss[1:] {
+		result += sep + s
+	}
+	return result
+}

--- a/meshant/graph/shadow_test.go
+++ b/meshant/graph/shadow_test.go
@@ -1,0 +1,199 @@
+package graph_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/graph"
+	"github.com/automatedtomato/mesh-ant/meshant/schema"
+)
+
+// makeShadowGraph builds a MeshGraph with a controlled shadow for testing.
+// It articulates from "observer-a" over two traces: one observed by "observer-a"
+// (included) and one by "observer-b" (excluded → shadow).
+func makeShadowGraph() graph.MeshGraph {
+	traces := []schema.Trace{
+		{
+			ID:          "a0000000-0000-4000-8000-000000000001",
+			WhatChanged: "A sees B",
+			Source:      []string{"element-a"},
+			Target:      []string{"element-b"},
+			Observer:    "observer-a",
+		},
+		{
+			ID:          "b0000000-0000-4000-8000-000000000002",
+			WhatChanged: "C sees D",
+			Source:      []string{"element-c"},
+			Target:      []string{"element-d"},
+			Observer:    "observer-b",
+		},
+	}
+	opts := graph.ArticulationOptions{
+		ObserverPositions: []string{"observer-a"},
+	}
+	return graph.Articulate(traces, opts)
+}
+
+// --- SummariseShadow ---
+
+func TestSummariseShadow_TotalShadowed(t *testing.T) {
+	g := makeShadowGraph()
+	s := graph.SummariseShadow(g)
+
+	// observer-b's trace contributes element-c and element-d to the shadow.
+	if s.TotalShadowed != 2 {
+		t.Errorf("TotalShadowed: got %d want 2", s.TotalShadowed)
+	}
+}
+
+func TestSummariseShadow_ByReason_Observer(t *testing.T) {
+	g := makeShadowGraph()
+	s := graph.SummariseShadow(g)
+
+	if s.ByReason["observer"] != 2 {
+		t.Errorf("ByReason[observer]: got %d want 2", s.ByReason["observer"])
+	}
+}
+
+func TestSummariseShadow_SeenFromCounts(t *testing.T) {
+	g := makeShadowGraph()
+	s := graph.SummariseShadow(g)
+
+	// Both shadow elements are seen from "observer-b".
+	if s.SeenFromCounts["observer-b"] != 2 {
+		t.Errorf("SeenFromCounts[observer-b]: got %d want 2", s.SeenFromCounts["observer-b"])
+	}
+}
+
+func TestSummariseShadow_Elements_Sorted(t *testing.T) {
+	g := makeShadowGraph()
+	s := graph.SummariseShadow(g)
+
+	if len(s.Elements) != 2 {
+		t.Fatalf("Elements length: got %d want 2", len(s.Elements))
+	}
+	// Elements should be sorted alphabetically (element-c < element-d).
+	if s.Elements[0].Name > s.Elements[1].Name {
+		t.Errorf("Elements not sorted: %q > %q", s.Elements[0].Name, s.Elements[1].Name)
+	}
+}
+
+func TestSummariseShadow_CutPreserved(t *testing.T) {
+	g := makeShadowGraph()
+	s := graph.SummariseShadow(g)
+
+	if len(s.Cut.ObserverPositions) == 0 || s.Cut.ObserverPositions[0] != "observer-a" {
+		t.Errorf("Cut.ObserverPositions: got %v want [observer-a]", s.Cut.ObserverPositions)
+	}
+}
+
+func TestSummariseShadow_NoShadow(t *testing.T) {
+	// Single-trace graph with no observer filter: no shadow.
+	traces := []schema.Trace{
+		{
+			ID:          "a0000000-0000-4000-8000-000000000001",
+			WhatChanged: "x", Source: []string{"a"}, Target: []string{"b"}, Observer: "obs",
+		},
+	}
+	g := graph.Articulate(traces, graph.ArticulationOptions{})
+	s := graph.SummariseShadow(g)
+
+	if s.TotalShadowed != 0 {
+		t.Errorf("TotalShadowed: got %d want 0", s.TotalShadowed)
+	}
+}
+
+func TestSummariseShadow_ElementsCopied(t *testing.T) {
+	// Mutating the returned Elements slice must not affect the original graph.
+	g := makeShadowGraph()
+	s := graph.SummariseShadow(g)
+
+	originalLen := len(g.Cut.ShadowElements)
+	s.Elements = append(s.Elements, graph.ShadowElement{Name: "injected"})
+
+	if len(g.Cut.ShadowElements) != originalLen {
+		t.Error("mutating ShadowSummary.Elements affected original MeshGraph.Cut.ShadowElements")
+	}
+}
+
+// --- PrintShadowSummary ---
+
+func TestPrintShadowSummary_ContainsExpectedContent(t *testing.T) {
+	g := makeShadowGraph()
+	s := graph.SummariseShadow(g)
+
+	var buf bytes.Buffer
+	if err := graph.PrintShadowSummary(&buf, s); err != nil {
+		t.Fatalf("PrintShadowSummary: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	checks := []string{
+		"Shadow Summary",
+		"observer-a",
+		"Shadow elements: 2",
+		"observer",
+		"element-c",
+		"element-d",
+		"observer-b",
+		"cut decision",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q;\noutput:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintShadowSummary_NoShadowMessage(t *testing.T) {
+	traces := []schema.Trace{
+		{
+			ID:          "a0000000-0000-4000-8000-000000000001",
+			WhatChanged: "x", Source: []string{"a"}, Target: []string{"b"}, Observer: "obs",
+		},
+	}
+	g := graph.Articulate(traces, graph.ArticulationOptions{})
+	s := graph.SummariseShadow(g)
+
+	var buf bytes.Buffer
+	if err := graph.PrintShadowSummary(&buf, s); err != nil {
+		t.Fatalf("PrintShadowSummary: unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "No shadow") {
+		t.Errorf("expected 'No shadow' message; output:\n%s", out)
+	}
+}
+
+func TestPrintShadowSummary_SeenFromOrdering(t *testing.T) {
+	// Build a graph where observer-b has 2 shadow elements and observer-c has 1.
+	// observer-b should appear first in the "visible from" section.
+	traces := []schema.Trace{
+		{ID: "1", WhatChanged: "a", Source: []string{"x"}, Target: []string{"y"}, Observer: "obs-a"},
+		{ID: "2", WhatChanged: "b", Source: []string{"p"}, Target: []string{"q"}, Observer: "obs-b"},
+		{ID: "3", WhatChanged: "c", Source: []string{"p"}, Target: []string{"r"}, Observer: "obs-b"},
+		{ID: "4", WhatChanged: "d", Source: []string{"s"}, Target: []string{"t"}, Observer: "obs-c"},
+	}
+	g := graph.Articulate(traces, graph.ArticulationOptions{
+		ObserverPositions: []string{"obs-a"},
+	})
+	s := graph.SummariseShadow(g)
+
+	var buf bytes.Buffer
+	if err := graph.PrintShadowSummary(&buf, s); err != nil {
+		t.Fatalf("PrintShadowSummary: %v", err)
+	}
+	out := buf.String()
+
+	// obs-b should appear before obs-c since it covers more shadow elements.
+	posB := strings.Index(out, "obs-b")
+	posC := strings.Index(out, "obs-c")
+	if posB == -1 || posC == -1 {
+		t.Fatalf("expected both obs-b and obs-c in output; output:\n%s", out)
+	}
+	if posB > posC {
+		t.Errorf("obs-b (higher count) should appear before obs-c in output")
+	}
+}


### PR DESCRIPTION
## Summary

- `SummariseShadow(g MeshGraph) ShadowSummary` — reads `Cut.ShadowElements`, counts by reason, builds `SeenFromCounts` (observer → shadow elements visible from there)
- `PrintShadowSummary` — shadow-first report: total excluded, by-reason breakdown, which observers would un-shadow the most, full element list
- 10 tests covering: totals, reasons, SeenFrom counts, sorted elements, cut preserved, no-shadow case, element isolation, output content, ordering

## ANT grounding

Shadow is a cut decision. The report names what this position cannot see without treating absence as a deficiency.

Closes #13