### PR TITLE
feat(graph): ObserverGap analysis and report (#14)

### DIFF
--- a/meshant/graph/gaps.go
+++ b/meshant/graph/gaps.go
@@ -1,0 +1,143 @@
+// gaps.go provides observer-gap analysis — comparing what two articulations
+// can and cannot see, without running a full diff.
+//
+// AnalyseGaps takes two already-articulated MeshGraphs and compares their
+// node sets. This is lighter than Diff: it focuses on element visibility
+// asymmetry rather than full structural comparison. The analyst's question
+// is: "what does A see that B does not, and vice versa?" — not "how did
+// the graph change?"
+//
+// Each graph carries its Cut, so ObserverGap is self-situated: it names
+// both positions being compared and names the asymmetry without treating
+// either as authoritative.
+package graph
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// ObserverGap records the visibility asymmetry between two articulations.
+// It does not say which is more correct — it says what each can see that
+// the other cannot, and what both can see.
+type ObserverGap struct {
+	// OnlyInA lists elements visible in graph A but not in graph B.
+	// Sorted alphabetically.
+	OnlyInA []string
+
+	// OnlyInB lists elements visible in graph B but not in graph A.
+	// Sorted alphabetically.
+	OnlyInB []string
+
+	// InBoth lists elements visible in both graphs.
+	// Sorted alphabetically.
+	InBoth []string
+
+	// CutA is the articulation parameters of graph A. Retained so the gap
+	// report is self-situated — a comparison without its positions is
+	// uninterpretable.
+	CutA Cut
+
+	// CutB is the articulation parameters of graph B.
+	CutB Cut
+}
+
+// AnalyseGaps compares the node sets of two already-articulated MeshGraphs
+// and returns an ObserverGap. It does not re-articulate; it reads only the
+// Nodes maps and Cut fields already present on g1 and g2.
+//
+// The returned ObserverGap is immutable — no slices alias the input graphs.
+func AnalyseGaps(g1, g2 MeshGraph) ObserverGap {
+	gap := ObserverGap{
+		CutA: g1.Cut,
+		CutB: g2.Cut,
+	}
+
+	// Build lookup sets for O(n) comparison.
+	inA := make(map[string]bool, len(g1.Nodes))
+	for name := range g1.Nodes {
+		inA[name] = true
+	}
+	inB := make(map[string]bool, len(g2.Nodes))
+	for name := range g2.Nodes {
+		inB[name] = true
+	}
+
+	for name := range inA {
+		if inB[name] {
+			gap.InBoth = append(gap.InBoth, name)
+		} else {
+			gap.OnlyInA = append(gap.OnlyInA, name)
+		}
+	}
+	for name := range inB {
+		if !inA[name] {
+			gap.OnlyInB = append(gap.OnlyInB, name)
+		}
+	}
+
+	sort.Strings(gap.OnlyInA)
+	sort.Strings(gap.OnlyInB)
+	sort.Strings(gap.InBoth)
+
+	return gap
+}
+
+// PrintObserverGap writes an observer-gap report to w.
+// The report shows both cut positions and the three-way element partition:
+// only in A, only in B, and in both. Neither position is treated as primary.
+//
+// Returns the first write error encountered, if any.
+func PrintObserverGap(w io.Writer, gap ObserverGap) error {
+	labelA := cutLabel(gap.CutA)
+	labelB := cutLabel(gap.CutB)
+
+	lines := []string{
+		"=== Observer Gap ===",
+		"",
+		fmt.Sprintf("Position A: %s", labelA),
+		fmt.Sprintf("Position B: %s", labelB),
+		"",
+		fmt.Sprintf("Only in A: %d  |  Only in B: %d  |  In both: %d",
+			len(gap.OnlyInA), len(gap.OnlyInB), len(gap.InBoth)),
+	}
+
+	if len(gap.OnlyInA) > 0 {
+		lines = append(lines, "", fmt.Sprintf("Elements only visible from A (%s):", labelA))
+		for _, name := range gap.OnlyInA {
+			lines = append(lines, "  "+name)
+		}
+	}
+
+	if len(gap.OnlyInB) > 0 {
+		lines = append(lines, "", fmt.Sprintf("Elements only visible from B (%s):", labelB))
+		for _, name := range gap.OnlyInB {
+			lines = append(lines, "  "+name)
+		}
+	}
+
+	if len(gap.InBoth) > 0 {
+		lines = append(lines, "", "Elements visible from both:")
+		for _, name := range gap.InBoth {
+			lines = append(lines, "  "+name)
+		}
+	}
+
+	if len(gap.OnlyInA) == 0 && len(gap.OnlyInB) == 0 {
+		lines = append(lines, "", "No gap — both positions see the same elements.")
+	}
+
+	lines = append(lines,
+		"",
+		"---",
+		"Note: neither position is authoritative. Each sees from where it stands.",
+	)
+
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("graph: PrintObserverGap: %w", err)
+		}
+	}
+	return nil
+}

--- a/meshant/graph/gaps_test.go
+++ b/meshant/graph/gaps_test.go
@@ -1,0 +1,185 @@
+package graph_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/graph"
+	"github.com/automatedtomato/mesh-ant/meshant/schema"
+)
+
+// makeGapGraphs returns two articulations of the same trace set from different
+// observer positions, for use in gap tests.
+//
+//   - obsA sees: element-a, element-b (from trace 1)
+//   - obsB sees: element-c, element-d (from trace 2)
+//   - trace 3 is seen by both: element-shared-src, element-shared-tgt
+func makeGapGraphs() (graph.MeshGraph, graph.MeshGraph) {
+	traces := []schema.Trace{
+		{
+			ID:          "a0000000-0000-4000-8000-000000000001",
+			WhatChanged: "A sees B",
+			Source:      []string{"element-a"},
+			Target:      []string{"element-b"},
+			Observer:    "obs-a",
+		},
+		{
+			ID:          "b0000000-0000-4000-8000-000000000002",
+			WhatChanged: "C sees D",
+			Source:      []string{"element-c"},
+			Target:      []string{"element-d"},
+			Observer:    "obs-b",
+		},
+		{
+			ID:          "c0000000-0000-4000-8000-000000000003",
+			WhatChanged: "shared",
+			Source:      []string{"element-shared-src"},
+			Target:      []string{"element-shared-tgt"},
+			Observer:    "obs-a",
+		},
+	}
+	gA := graph.Articulate(traces, graph.ArticulationOptions{ObserverPositions: []string{"obs-a"}})
+	gB := graph.Articulate(traces, graph.ArticulationOptions{ObserverPositions: []string{"obs-b"}})
+	return gA, gB
+}
+
+// --- AnalyseGaps ---
+
+func TestAnalyseGaps_OnlyInA(t *testing.T) {
+	gA, gB := makeGapGraphs()
+	gap := graph.AnalyseGaps(gA, gB)
+
+	// obs-a sees element-a, element-b, element-shared-src, element-shared-tgt
+	// obs-b sees element-c, element-d
+	// Only in A: element-a, element-b, element-shared-src, element-shared-tgt
+	if len(gap.OnlyInA) != 4 {
+		t.Errorf("OnlyInA: got %d want 4; elements: %v", len(gap.OnlyInA), gap.OnlyInA)
+	}
+}
+
+func TestAnalyseGaps_OnlyInB(t *testing.T) {
+	gA, gB := makeGapGraphs()
+	gap := graph.AnalyseGaps(gA, gB)
+
+	// Only in B: element-c, element-d
+	if len(gap.OnlyInB) != 2 {
+		t.Errorf("OnlyInB: got %d want 2; elements: %v", len(gap.OnlyInB), gap.OnlyInB)
+	}
+}
+
+func TestAnalyseGaps_InBoth(t *testing.T) {
+	// Both observers see the same trace.
+	traces := []schema.Trace{
+		{
+			ID: "1", WhatChanged: "shared",
+			Source: []string{"shared-src"}, Target: []string{"shared-tgt"},
+			Observer: "obs-a",
+		},
+		{
+			ID: "2", WhatChanged: "shared",
+			Source: []string{"shared-src"}, Target: []string{"shared-tgt"},
+			Observer: "obs-b",
+		},
+	}
+	gA := graph.Articulate(traces, graph.ArticulationOptions{ObserverPositions: []string{"obs-a"}})
+	gB := graph.Articulate(traces, graph.ArticulationOptions{ObserverPositions: []string{"obs-b"}})
+	gap := graph.AnalyseGaps(gA, gB)
+
+	if len(gap.InBoth) != 2 {
+		t.Errorf("InBoth: got %d want 2; elements: %v", len(gap.InBoth), gap.InBoth)
+	}
+	if len(gap.OnlyInA) != 0 || len(gap.OnlyInB) != 0 {
+		t.Errorf("expected no exclusive elements; OnlyInA=%v OnlyInB=%v", gap.OnlyInA, gap.OnlyInB)
+	}
+}
+
+func TestAnalyseGaps_SortedAlphabetically(t *testing.T) {
+	gA, gB := makeGapGraphs()
+	gap := graph.AnalyseGaps(gA, gB)
+
+	checkSorted := func(label string, ss []string) {
+		for i := 1; i < len(ss); i++ {
+			if ss[i-1] > ss[i] {
+				t.Errorf("%s not sorted: %q > %q", label, ss[i-1], ss[i])
+			}
+		}
+	}
+	checkSorted("OnlyInA", gap.OnlyInA)
+	checkSorted("OnlyInB", gap.OnlyInB)
+	checkSorted("InBoth", gap.InBoth)
+}
+
+func TestAnalyseGaps_CutsPreserved(t *testing.T) {
+	gA, gB := makeGapGraphs()
+	gap := graph.AnalyseGaps(gA, gB)
+
+	if len(gap.CutA.ObserverPositions) == 0 || gap.CutA.ObserverPositions[0] != "obs-a" {
+		t.Errorf("CutA: got %v want [obs-a]", gap.CutA.ObserverPositions)
+	}
+	if len(gap.CutB.ObserverPositions) == 0 || gap.CutB.ObserverPositions[0] != "obs-b" {
+		t.Errorf("CutB: got %v want [obs-b]", gap.CutB.ObserverPositions)
+	}
+}
+
+func TestAnalyseGaps_NoGap_IdenticalGraphs(t *testing.T) {
+	traces := []schema.Trace{
+		{ID: "1", WhatChanged: "x", Source: []string{"a"}, Target: []string{"b"}, Observer: "obs"},
+	}
+	g := graph.Articulate(traces, graph.ArticulationOptions{})
+	gap := graph.AnalyseGaps(g, g)
+
+	if len(gap.OnlyInA) != 0 || len(gap.OnlyInB) != 0 {
+		t.Errorf("identical graphs: expected no gap; OnlyInA=%v OnlyInB=%v", gap.OnlyInA, gap.OnlyInB)
+	}
+	if len(gap.InBoth) != 2 { // element a and b
+		t.Errorf("InBoth: got %d want 2", len(gap.InBoth))
+	}
+}
+
+// --- PrintObserverGap ---
+
+func TestPrintObserverGap_ContainsExpectedContent(t *testing.T) {
+	gA, gB := makeGapGraphs()
+	gap := graph.AnalyseGaps(gA, gB)
+
+	var buf bytes.Buffer
+	if err := graph.PrintObserverGap(&buf, gap); err != nil {
+		t.Fatalf("PrintObserverGap: %v", err)
+	}
+	out := buf.String()
+
+	checks := []string{
+		"Observer Gap",
+		"obs-a",
+		"obs-b",
+		"Only in A",
+		"Only in B",
+		"element-a",
+		"element-c",
+		"authoritative",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q;\noutput:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintObserverGap_NoGapMessage(t *testing.T) {
+	traces := []schema.Trace{
+		{ID: "1", WhatChanged: "x", Source: []string{"a"}, Target: []string{"b"}, Observer: "obs"},
+	}
+	g := graph.Articulate(traces, graph.ArticulationOptions{})
+	gap := graph.AnalyseGaps(g, g)
+
+	var buf bytes.Buffer
+	if err := graph.PrintObserverGap(&buf, gap); err != nil {
+		t.Fatalf("PrintObserverGap: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "No gap") {
+		t.Errorf("expected 'No gap' message; output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `AnalyseGaps(g1, g2 MeshGraph) ObserverGap` comparing two pre-articulated graph node sets
- Adds `PrintObserverGap(w io.Writer, gap ObserverGap) error` rendering a self-situated gap report
- `ObserverGap` carries `OnlyInA`, `OnlyInB`, `InBoth` (all sorted), plus both `Cut`s for provenance
- Takes pre-articulated `MeshGraph` values — keeps the operation composable, not re-articulating internally
- Reuses `cutLabel` from `reflexive.go`; no new helpers added

## Design

Neither position is authoritative. The report names both observer positions and the visibility asymmetry between them — consistent with ANT's generalised symmetry principle.

## Test plan

- `TestAnalyseGaps_OnlyInA`, `_OnlyInB`, `_InBoth` — correct partitioning
- `TestAnalyseGaps_SortedAlphabetically` — all three slices sorted
- `TestAnalyseGaps_CutsPreserved` — both cuts retained on result
- `TestAnalyseGaps_NoGap_IdenticalGraphs` — same graph both sides
- `TestPrintObserverGap_ContainsExpectedContent` — output includes both labels, element names, "authoritative"
- `TestPrintObserverGap_NoGapMessage` — "No gap" message when identical

`go test ./graph/...` ✓  `go vet ./...` ✓

Closes #14