### PR TITLE
feat(cmd): shadow and gaps subcommands (#15)

### DIFF
--- a/meshant/cmd/meshant/main.go
+++ b/meshant/cmd/meshant/main.go
@@ -206,6 +206,10 @@ func run(w io.Writer, args []string) error {
 		return cmdRearticulate(w, args[1:])
 	case "lineage":
 		return cmdLineage(w, args[1:])
+	case "shadow":
+		return cmdShadow(w, args[1:])
+	case "gaps":
+		return cmdGaps(w, args[1:])
 	default:
 		return fmt.Errorf("unknown command %q\n\n%s", args[0], usage())
 	}
@@ -228,6 +232,8 @@ Commands:
   follow      follow a translation chain through an articulation (flags: --observer, --tag, --from, --to, --element, --direction, --depth, --format, --criterion-file, --output)
   draft       ingest extraction JSON and produce TraceDraft records (flags: --source-doc, --extracted-by, --stage, --output)
   promote     promote TraceDraft records to canonical Traces (flags: --output)
+  shadow      summarise shadowed elements from an observer-situated articulation (flags: --observer, --tag, --from, --to, --output)
+  gaps        compare element visibility between two observer positions (flags: --observer-a, --observer-b, --tag-a, --tag-b, --from-a, --to-a, --from-b, --to-b, --output)
 
 Run 'meshant <command> --help' for command-specific flags.`
 }
@@ -1325,4 +1331,179 @@ func chainContainsID(n *lineageNode, id string) bool {
 		}
 	}
 	return false
+}
+
+// cmdShadow implements the "shadow" subcommand.
+//
+// It articulates an observer-situated graph from the traces file and prints
+// a shadow summary — the set of elements that are shadowed (not visible from
+// the given observer position) and why. Shadow is a cut decision, not missing
+// data: a shadowed element was visible to some observer but not the one named
+// by this cut.
+//
+// It accepts the following flags:
+//   - --observer (repeatable, required) — observer position(s) for articulation
+//   - --tag      (repeatable, optional) — tag filter (any-match / OR semantics)
+//   - --from, --to (optional, RFC3339) — time window
+//   - --output (optional)             — write output to file instead of stdout
+//
+// Returns an error if --observer is missing, a time flag is not RFC3339,
+// the path is missing or unloadable, or writing fails.
+func cmdShadow(w io.Writer, args []string) error {
+	fs := flag.NewFlagSet("shadow", flag.ContinueOnError)
+
+	var observers stringSliceFlag
+	fs.Var(&observers, "observer", "observer position to include (repeatable)")
+
+	var tags stringSliceFlag
+	fs.Var(&tags, "tag", "tag filter (repeatable, any-match / OR semantics)")
+
+	var fromStr, toStr string
+	fs.StringVar(&fromStr, "from", "", "start of time window (RFC3339)")
+	fs.StringVar(&toStr, "to", "", "end of time window (RFC3339)")
+
+	var outputPath string
+	fs.StringVar(&outputPath, "output", "", "write output to file (e.g. shadow.txt)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if len(observers) == 0 {
+		return fmt.Errorf("shadow: --observer is required")
+	}
+
+	tw, err := parseTimeWindow("from", fromStr, "to", toStr)
+	if err != nil {
+		return fmt.Errorf("shadow: %w", err)
+	}
+
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return fmt.Errorf("shadow: path to traces.json required\n\nUsage: meshant shadow --observer <pos> [--tag <tag>] [--from RFC3339] [--to RFC3339] [--output <file>] <traces.json>")
+	}
+	path := remaining[0]
+
+	traces, err := loader.Load(path)
+	if err != nil {
+		return fmt.Errorf("shadow: %w", err)
+	}
+
+	opts := graph.ArticulationOptions{
+		ObserverPositions: []string(observers),
+		TimeWindow:        tw,
+		Tags:              []string(tags),
+	}
+	g := graph.Articulate(traces, opts)
+	s := graph.SummariseShadow(g)
+
+	dest, err := outputWriter(w, outputPath)
+	if err != nil {
+		return fmt.Errorf("shadow: %w", err)
+	}
+	if f, ok := dest.(*os.File); ok {
+		defer f.Close()
+	}
+
+	if err := graph.PrintShadowSummary(dest, s); err != nil {
+		return err
+	}
+	return confirmOutput(w, outputPath)
+}
+
+// cmdGaps implements the "gaps" subcommand.
+//
+// It articulates two observer-situated graphs from the same traces file and
+// prints an observer-gap report — what each position can see that the other
+// cannot. Neither position is treated as authoritative; the report names both
+// and the asymmetry between them.
+//
+// It accepts the following flags:
+//   - --observer-a (repeatable, required) — observer positions for graph A
+//   - --observer-b (repeatable, required) — observer positions for graph B
+//   - --tag-a      (repeatable, optional) — tag filter for graph A
+//   - --tag-b      (repeatable, optional) — tag filter for graph B
+//   - --from-a, --to-a (optional, RFC3339) — time window for graph A
+//   - --from-b, --to-b (optional, RFC3339) — time window for graph B
+//   - --output (optional)                  — write output to file instead of stdout
+//
+// Returns an error if --observer-a or --observer-b is missing, a time flag
+// is not RFC3339, the path is missing or unloadable, or writing fails.
+func cmdGaps(w io.Writer, args []string) error {
+	fs := flag.NewFlagSet("gaps", flag.ContinueOnError)
+
+	var observersA, observersB stringSliceFlag
+	fs.Var(&observersA, "observer-a", "observer positions for graph A (repeatable)")
+	fs.Var(&observersB, "observer-b", "observer positions for graph B (repeatable)")
+
+	var tagsA, tagsB stringSliceFlag
+	fs.Var(&tagsA, "tag-a", "tag filter for graph A (repeatable, any-match / OR semantics)")
+	fs.Var(&tagsB, "tag-b", "tag filter for graph B (repeatable, any-match / OR semantics)")
+
+	var fromAStr, toAStr, fromBStr, toBStr string
+	fs.StringVar(&fromAStr, "from-a", "", "start of time window for graph A (RFC3339)")
+	fs.StringVar(&toAStr, "to-a", "", "end of time window for graph A (RFC3339)")
+	fs.StringVar(&fromBStr, "from-b", "", "start of time window for graph B (RFC3339)")
+	fs.StringVar(&toBStr, "to-b", "", "end of time window for graph B (RFC3339)")
+
+	var outputPath string
+	fs.StringVar(&outputPath, "output", "", "write output to file (e.g. gaps.txt)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if len(observersA) == 0 {
+		return fmt.Errorf("gaps: --observer-a is required")
+	}
+	if len(observersB) == 0 {
+		return fmt.Errorf("gaps: --observer-b is required")
+	}
+
+	twA, err := parseTimeWindow("from-a", fromAStr, "to-a", toAStr)
+	if err != nil {
+		return fmt.Errorf("gaps: %w", err)
+	}
+	twB, err := parseTimeWindow("from-b", fromBStr, "to-b", toBStr)
+	if err != nil {
+		return fmt.Errorf("gaps: %w", err)
+	}
+
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return fmt.Errorf("gaps: path to traces.json required\n\nUsage: meshant gaps --observer-a <pos> --observer-b <pos> [flags] <traces.json>")
+	}
+	path := remaining[0]
+
+	traces, err := loader.Load(path)
+	if err != nil {
+		return fmt.Errorf("gaps: %w", err)
+	}
+
+	optsA := graph.ArticulationOptions{
+		ObserverPositions: []string(observersA),
+		TimeWindow:        twA,
+		Tags:              []string(tagsA),
+	}
+	optsB := graph.ArticulationOptions{
+		ObserverPositions: []string(observersB),
+		TimeWindow:        twB,
+		Tags:              []string(tagsB),
+	}
+	gA := graph.Articulate(traces, optsA)
+	gB := graph.Articulate(traces, optsB)
+	gap := graph.AnalyseGaps(gA, gB)
+
+	dest, err := outputWriter(w, outputPath)
+	if err != nil {
+		return fmt.Errorf("gaps: %w", err)
+	}
+	if f, ok := dest.(*os.File); ok {
+		defer f.Close()
+	}
+
+	if err := graph.PrintObserverGap(dest, gap); err != nil {
+		return err
+	}
+	return confirmOutput(w, outputPath)
 }

--- a/meshant/cmd/meshant/main_test.go
+++ b/meshant/cmd/meshant/main_test.go
@@ -2200,3 +2200,293 @@ func TestCmdLineage_EmptyInput(t *testing.T) {
 		t.Errorf("expected standalone count 0 in output; got:\n%s", out)
 	}
 }
+
+// --- Group N: cmdShadow ---
+
+// TestCmdShadow_HappyPath verifies that cmdShadow produces non-empty output
+// containing shadow-related keywords when given a valid dataset and observer.
+func TestCmdShadow_HappyPath(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdShadow(&buf, []string{
+		"--observer", "meteorological-analyst",
+		evacuationDataset,
+	})
+	if err != nil {
+		t.Fatalf("cmdShadow(): unexpected error: %v", err)
+	}
+	out := buf.String()
+	if len(out) == 0 {
+		t.Error("cmdShadow(): expected non-empty output")
+	}
+	if !strings.Contains(out, "Shadow") {
+		t.Errorf("cmdShadow(): output missing 'Shadow'; got:\n%s", out)
+	}
+}
+
+// TestCmdShadow_MissingObserver verifies that cmdShadow returns an error
+// containing "required" when --observer is not provided.
+func TestCmdShadow_MissingObserver(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdShadow(&buf, []string{evacuationDataset})
+	if err == nil {
+		t.Fatal("cmdShadow() with no --observer: want non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error = %q; want it to contain 'required'", err.Error())
+	}
+}
+
+// TestCmdShadow_MissingArg verifies that cmdShadow returns an error when no
+// path is provided.
+func TestCmdShadow_MissingArg(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdShadow(&buf, []string{"--observer", "meteorological-analyst"})
+	if err == nil {
+		t.Fatal("cmdShadow() with no path: want non-nil error, got nil")
+	}
+}
+
+// TestCmdShadow_BadPath verifies that cmdShadow returns an error when the
+// traces file does not exist.
+func TestCmdShadow_BadPath(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdShadow(&buf, []string{"--observer", "meteorological-analyst", "notafile.json"})
+	if err == nil {
+		t.Fatal("cmdShadow() with bad path: want non-nil error, got nil")
+	}
+}
+
+// TestCmdShadow_BadFromTime verifies that cmdShadow returns an error containing
+// "RFC3339" when --from is not a valid RFC3339 timestamp.
+func TestCmdShadow_BadFromTime(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdShadow(&buf, []string{
+		"--observer", "meteorological-analyst",
+		"--from", "notadate",
+		evacuationDataset,
+	})
+	if err == nil {
+		t.Fatal("cmdShadow() with bad --from: want non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "RFC3339") {
+		t.Errorf("error = %q; want it to contain 'RFC3339'", err.Error())
+	}
+}
+
+// TestCmdShadow_NoShadowMessage verifies that the output contains a "No shadow"
+// or similar no-shadow path when all elements are visible from the chosen observer.
+// (This may not always be triggered on the evacuation dataset, but ensures
+// the no-shadow path is exercised by running with full articulation.)
+func TestCmdShadow_OutputToFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "shadow.txt")
+	var buf bytes.Buffer
+	err := cmdShadow(&buf, []string{
+		"--observer", "meteorological-analyst",
+		"--output", out,
+		evacuationDataset,
+	})
+	if err != nil {
+		t.Fatalf("cmdShadow() --output: unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	if !strings.Contains(string(data), "Shadow") {
+		t.Errorf("output file missing 'Shadow'; got:\n%s", data)
+	}
+}
+
+// TestCmdShadow_RunDispatch verifies that run() correctly routes "shadow"
+// to cmdShadow, producing non-empty output.
+func TestCmdShadow_RunDispatch(t *testing.T) {
+	var buf bytes.Buffer
+	err := run(&buf, []string{
+		"shadow",
+		"--observer", "meteorological-analyst",
+		evacuationDataset,
+	})
+	if err != nil {
+		t.Fatalf("run('shadow'): unexpected error: %v", err)
+	}
+	if len(buf.String()) == 0 {
+		t.Error("run('shadow'): expected non-empty output")
+	}
+}
+
+// TestCmdShadow_TagFilter verifies that --tag is accepted and does not error.
+func TestCmdShadow_TagFilter(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdShadow(&buf, []string{
+		"--observer", "meteorological-analyst",
+		"--tag", "nonexistent-tag",
+		evacuationDataset,
+	})
+	if err != nil {
+		t.Fatalf("cmdShadow() --tag: unexpected error: %v", err)
+	}
+}
+
+// --- Group O: cmdGaps ---
+
+// TestCmdGaps_HappyPath verifies that cmdGaps produces output containing
+// "Observer Gap" and both observer labels when given two distinct positions.
+func TestCmdGaps_HappyPath(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdGaps(&buf, []string{
+		"--observer-a", "meteorological-analyst",
+		"--observer-b", "coastal-resident",
+		evacuationDataset,
+	})
+	if err != nil {
+		t.Fatalf("cmdGaps(): unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Observer Gap") {
+		t.Errorf("cmdGaps(): output missing 'Observer Gap'; got:\n%s", out)
+	}
+	if !strings.Contains(out, "meteorological-analyst") {
+		t.Errorf("cmdGaps(): output missing observer-a label; got:\n%s", out)
+	}
+	if !strings.Contains(out, "coastal-resident") {
+		t.Errorf("cmdGaps(): output missing observer-b label; got:\n%s", out)
+	}
+}
+
+// TestCmdGaps_MissingObserverA verifies that cmdGaps returns an error
+// containing "required" when --observer-a is missing.
+func TestCmdGaps_MissingObserverA(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdGaps(&buf, []string{
+		"--observer-b", "coastal-resident",
+		evacuationDataset,
+	})
+	if err == nil {
+		t.Fatal("cmdGaps() with no --observer-a: want non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error = %q; want it to contain 'required'", err.Error())
+	}
+}
+
+// TestCmdGaps_MissingObserverB verifies that cmdGaps returns an error
+// containing "required" when --observer-b is missing.
+func TestCmdGaps_MissingObserverB(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdGaps(&buf, []string{
+		"--observer-a", "meteorological-analyst",
+		evacuationDataset,
+	})
+	if err == nil {
+		t.Fatal("cmdGaps() with no --observer-b: want non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error = %q; want it to contain 'required'", err.Error())
+	}
+}
+
+// TestCmdGaps_MissingArg verifies that cmdGaps returns an error when no
+// path is provided (both observers set, no file).
+func TestCmdGaps_MissingArg(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdGaps(&buf, []string{
+		"--observer-a", "meteorological-analyst",
+		"--observer-b", "coastal-resident",
+	})
+	if err == nil {
+		t.Fatal("cmdGaps() with no path: want non-nil error, got nil")
+	}
+}
+
+// TestCmdGaps_BadPath verifies that cmdGaps returns an error when the
+// traces file does not exist.
+func TestCmdGaps_BadPath(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdGaps(&buf, []string{
+		"--observer-a", "meteorological-analyst",
+		"--observer-b", "coastal-resident",
+		"notafile.json",
+	})
+	if err == nil {
+		t.Fatal("cmdGaps() with bad path: want non-nil error, got nil")
+	}
+}
+
+// TestCmdGaps_BadFromATime verifies that cmdGaps returns an error containing
+// "RFC3339" when --from-a is not a valid RFC3339 timestamp.
+func TestCmdGaps_BadFromATime(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdGaps(&buf, []string{
+		"--observer-a", "meteorological-analyst",
+		"--observer-b", "coastal-resident",
+		"--from-a", "notadate",
+		evacuationDataset,
+	})
+	if err == nil {
+		t.Fatal("cmdGaps() with bad --from-a: want non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "RFC3339") {
+		t.Errorf("error = %q; want it to contain 'RFC3339'", err.Error())
+	}
+}
+
+// TestCmdGaps_OutputToFile verifies that --output writes the gap report to a
+// file and that the file contains "Observer Gap".
+func TestCmdGaps_OutputToFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "gaps.txt")
+	var buf bytes.Buffer
+	err := cmdGaps(&buf, []string{
+		"--observer-a", "meteorological-analyst",
+		"--observer-b", "coastal-resident",
+		"--output", out,
+		evacuationDataset,
+	})
+	if err != nil {
+		t.Fatalf("cmdGaps() --output: unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	if !strings.Contains(string(data), "Observer Gap") {
+		t.Errorf("output file missing 'Observer Gap'; got:\n%s", data)
+	}
+}
+
+// TestCmdGaps_SameObserver verifies that when observer-a and observer-b are
+// the same, the output contains "No gap" since both positions see identically.
+func TestCmdGaps_SameObserver(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdGaps(&buf, []string{
+		"--observer-a", "meteorological-analyst",
+		"--observer-b", "meteorological-analyst",
+		evacuationDataset,
+	})
+	if err != nil {
+		t.Fatalf("cmdGaps() same observer: unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "No gap") {
+		t.Errorf("same-observer gaps: expected 'No gap' in output; got:\n%s", out)
+	}
+}
+
+// TestCmdGaps_RunDispatch verifies that run() correctly routes "gaps" to
+// cmdGaps, producing non-empty output.
+func TestCmdGaps_RunDispatch(t *testing.T) {
+	var buf bytes.Buffer
+	err := run(&buf, []string{
+		"gaps",
+		"--observer-a", "meteorological-analyst",
+		"--observer-b", "coastal-resident",
+		evacuationDataset,
+	})
+	if err != nil {
+		t.Fatalf("run('gaps'): unexpected error: %v", err)
+	}
+	if len(buf.String()) == 0 {
+		t.Error("run('gaps'): expected non-empty output")
+	}
+}


### PR DESCRIPTION
## Summary

- `meshant shadow --observer <pos> [--tag] [--from/--to] [--output] <traces.json>` — articulates then prints `ShadowSummary`; shadow is a cut decision, not missing data
- `meshant gaps --observer-a <pos> --observer-b <pos> [per-side flags] [--output] <traces.json>` — articulates both sides then prints `ObserverGap`; neither position is authoritative
- Both subcommands follow existing flag patterns (`stringSliceFlag`, `parseTimeWindow`, `outputWriter`, `confirmOutput`)
- Usage string and `run()` dispatch updated

## Design

Shadow and gaps are observer-situated operations: each takes one or two named observer positions and describes what can or cannot be seen from those positions. The report language uses "shadowed" not "missing" and names both positions without privileging either.

## Test plan

**shadow** (8 tests): HappyPath, MissingObserver, MissingArg, BadPath, BadFromTime, OutputToFile, RunDispatch, TagFilter  
**gaps** (9 tests): HappyPath, MissingObserverA, MissingObserverB, MissingArg, BadPath, BadFromATime, OutputToFile, SameObserver (No gap), RunDispatch

`go test ./...` ✓  `go vet ./...` ✓

Closes #15