### PR TITLE
docs: M13 decision record, codemap, todo completion (#16)

### DIFF
--- a/docs/CODEMAPS/meshant.md
+++ b/docs/CODEMAPS/meshant.md
@@ -1,6 +1,6 @@
 # MeshAnt — Codemap
 
-**Last Updated:** 2026-03-17 (M12 Re-articulation Pass)
+**Last Updated:** 2026-03-17 (M13 Shadow Analysis + Observer Gap + Ingestion Deepening)
 **Module:** `github.com/automatedtomato/mesh-ant/meshant`
 **Go Version:** 1.25
 **Root Directory:** `/meshant`
@@ -11,10 +11,10 @@
 |---------|---------|
 | `schema` | Core trace types, graph-reference predicates, and validators. |
 | `loader` | Load traces from JSON, summarize datasets, print summaries. |
-| `graph` | Articulate graphs, compute diffs, identify graphs as actors, reflexive tracing, follow translation chains, classify chains, export to JSON/DOT/Mermaid. |
+| `graph` | Articulate graphs, compute diffs, identify graphs as actors, reflexive tracing, follow translation chains, classify chains, shadow analysis, observer-gap analysis, export to JSON/DOT/Mermaid. |
 | `persist` | Read and write graphs to JSON files. |
 | `cmd/demo` | Minimal demonstration: two observer-position cuts on evacuation dataset. |
-| `cmd/meshant` | CLI entry point: `summarize`, `validate`, `articulate`, `diff`, `follow`, `draft`, `promote`, `rearticulate`, `lineage` subcommands. |
+| `cmd/meshant` | CLI entry point: `summarize`, `validate`, `articulate`, `diff`, `follow`, `draft`, `promote`, `rearticulate`, `lineage`, `shadow`, `gaps` subcommands. |
 
 ## Package: schema
 
@@ -32,7 +32,7 @@
 |------|-----------|---------|
 | `Trace` | `ID` (uuid), `Timestamp` (time), `WhatChanged` (string), `Source` ([]string), `Target` ([]string), `Mediation` (string), `Tags` ([]string), `Observer` (string, required) | Fundamental unit of record: a moment where something made a difference in a network. |
 | `TagValue` | (string constant type) | Vocabulary for trace descriptors: `TagDelay`, `TagThreshold`, `TagBlockage`, `TagAmplification`, `TagRedirection`, `TagTranslation`, `TagValueArticulation`, `TagValueDraft` (M11). |
-| `TraceDraft` | `ID` (uuid, optional), `Timestamp` (time), `SourceSpan` (string, required), `SourceDocRef` (string), `WhatChanged` (string), `Source` ([]string), `Target` ([]string), `Mediation` (string), `Observer` (string), `Tags` ([]string), `UncertaintyNote` (string), `ExtractionStage` (string), `ExtractedBy` (string), `DerivedFrom` (string) | Provisional, provenance-bearing record from ingestion pipeline. Minimal requirement: `SourceSpan`. May be promoted to canonical `Trace` when sufficiently complete (M11). |
+| `TraceDraft` | `ID` (uuid, optional), `Timestamp` (time), `SourceSpan` (string, required), `SourceDocRef` (string), `WhatChanged` (string), `Source` ([]string), `Target` ([]string), `Mediation` (string), `Observer` (string), `Tags` ([]string), `UncertaintyNote` (string), `ExtractionStage` (string), `ExtractedBy` (string), `DerivedFrom` (string), `CriterionRef` (string, M13), `IntentionallyBlank` ([]string, M12.5) | Provisional, provenance-bearing record from ingestion pipeline. Minimal requirement: `SourceSpan`. May be promoted to canonical `Trace` when sufficiently complete (M11). `CriterionRef` names the EquivalenceCriterion governing a critique skeleton (citation, not copy). `IntentionallyBlank` names content fields deliberately left empty (honest abstention, not missing data). |
 
 ### Functions
 
@@ -53,7 +53,8 @@
 | File | Contains |
 |------|----------|
 | `loader.go` | `Load`, `Summarise`, `PrintSummary`; `MeshSummary`, `FlaggedTrace` types. |
-| `draftloader.go` | `LoadDrafts`, `SummariseDrafts`, `PrintDraftSummary`; `DraftSummary` type; UUID generation (M11). |
+| `draftloader.go` | `LoadDrafts`, `SummariseDrafts`, `PrintDraftSummary`; `DraftSummary` type; UUID generation (M11). `WithIntentionallyBlank` and `WithCriterionRef` counts added (M12.5, M13). |
+| `draftchain.go` | `FollowDraftChain`, `ClassifyDraftChain`; `DraftStepKind`, `DraftStepClassification` types (M13). |
 
 ### Types
 
@@ -61,7 +62,9 @@
 |------|-----------|---------|
 | `MeshSummary` | `Elements` (map[string]int), `Mediations` ([]string), `MediatedTraceCount` (int), `FlaggedTraces` ([]FlaggedTrace), `GraphRefs` ([]string) | Provisional first-pass reading of a trace dataset. |
 | `FlaggedTrace` | `ID` (string), `WhatChanged` (string), `Tags` ([]string) | Minimal projection of traces tagged delay or threshold. |
-| `DraftSummary` | `Total` (int), `Promotable` (int), `ByStage` (map[string]int), `ByExtractedBy` (map[string]int), `FieldFillRate` (map[string]int) | Provenance-aware reading of a TraceDraft dataset. Reveals ingestion pipeline breakdown and field fill rates (M11). |
+| `DraftSummary` | `Total` (int), `Promotable` (int), `ByStage` (map[string]int), `ByExtractedBy` (map[string]int), `FieldFillRate` (map[string]int), `WithIntentionallyBlank` (int, M12.5), `WithCriterionRef` (int, M13) | Provenance-aware reading of a TraceDraft dataset. Reveals ingestion pipeline breakdown and field fill rates (M11). Counts critique skeletons and self-situated skeletons. |
+| `DraftStepKind` | (string constant: `DraftIntermediary`, `DraftMediator`, `DraftTranslation`) | Classification of a draft chain step; mirrors `StepKind` from graph package. Heuristics are v1 and provisional (M13). |
+| `DraftStepClassification` | `StepIndex` (int), `Kind` (DraftStepKind), `Reason` (string) | Classification and justification for a single draft chain step (M13). |
 
 ### Functions
 
@@ -72,7 +75,9 @@
 | `PrintSummary` | `func PrintSummary(w io.Writer, s MeshSummary) error` | Write formatted summary to io.Writer. Elements sorted by descending frequency, mediations in encounter order. |
 | `LoadDrafts` | `func LoadDrafts(path string) ([]schema.TraceDraft, error)` | Load JSON file of TraceDraft records; assign UUIDs and timestamps to missing fields; validate each via `TraceDraft.Validate()`; max 50 MB (M11). |
 | `SummariseDrafts` | `func SummariseDrafts(drafts []schema.TraceDraft) DraftSummary` | Build DraftSummary from TraceDraft slice: count by stage/extracted-by, count promotable records, compute per-field fill rates (M11). |
-| `PrintDraftSummary` | `func PrintDraftSummary(w io.Writer, s DraftSummary) error` | Write provenance summary to io.Writer. Shows total/promotable, breakdown by extraction stage and extracted_by, per-field fill rates (M11). |
+| `PrintDraftSummary` | `func PrintDraftSummary(w io.Writer, s DraftSummary) error` | Write provenance summary to io.Writer. Shows total/promotable, breakdown by extraction stage and extracted_by, per-field fill rates, critique skeleton counts (M11, M12.5, M13). |
+| `FollowDraftChain` | `func FollowDraftChain(drafts []schema.TraceDraft, from string) []schema.TraceDraft` | Traverse DerivedFrom links from draft with id `from`; return chain in derivation order. Empty slice if `from` not found. Cycle detection via visited set (M13). |
+| `ClassifyDraftChain` | `func ClassifyDraftChain(chain []schema.TraceDraft) []DraftStepClassification` | Apply v1 heuristic classification to consecutive draft pairs. Returns `len(chain)-1` classifications (M13). |
 
 ## Package: graph
 
@@ -90,6 +95,8 @@
 | `classify.go` | Chain classification: `ClassifiedChain`, `StepClassification`, `StepKind`, `ClassifyOptions`. `ClassifyChain()` function. Heuristic classification (intermediary, mediator, translation). Carries criterion as envelope metadata. |
 | `chain_print.go` | Chain output formatting: `PrintChain`, `PrintChainJSON`. Text and JSON rendering of classified chains, including criterion block when present. |
 | `export.go` | Export functions: `PrintGraphJSON`, `PrintDiffJSON`, `PrintGraphDOT`, `PrintGraphMermaid`, `PrintDiffDOT`, `PrintDiffMermaid`. Internal helpers for DOT/Mermaid formatting. `stripNewlines()` security helper prevents injection from crafted trace values. |
+| `shadow.go` | Shadow analysis: `SummariseShadow`, `PrintShadowSummary`; `ShadowSummary` type (M13). |
+| `gaps.go` | Observer-gap analysis: `AnalyseGaps`, `PrintObserverGap`; `ObserverGap` type (M13). |
 
 ### Types
 
@@ -118,6 +125,8 @@
 | `StepClassification` | `StepIndex` (int), `Kind` (StepKind), `Reason` (string) | Classification and justification for a single chain step. Reason strings are purely edge-driven (v1 heuristics). |
 | `ClassifiedChain` | `Chain` (TranslationChain), `Classifications` ([]StepClassification), `Criterion` (EquivalenceCriterion) | Translation chain with step-by-step classifications and optional criterion metadata. Criterion is envelope-only — does not alter v1 heuristics. |
 | `ClassifyOptions` | `Criterion` (EquivalenceCriterion) | Parameters for chain classification. Zero value = v1 heuristics (backwards-compatible). Criterion is carried into ClassifiedChain as provenance; does not alter step logic yet. |
+| `ShadowSummary` | `TotalShadowed` (int), `ByReason` (map[string]int), `Elements` ([]ShadowElement), `SeenFromCounts` (map[string]int), `Cut` (Cut) | Summary of shadowed elements in an articulated graph. ByReason counts by ShadowReason; SeenFromCounts maps excluded observer position to the count of elements seen from it; Elements sorted by name (M13). |
+| `ObserverGap` | `OnlyInA` ([]string), `OnlyInB` ([]string), `InBoth` ([]string), `CutA` (Cut), `CutB` (Cut) | Visibility asymmetry between two articulations. All three element lists sorted alphabetically. Both cuts retained for self-situated reporting (M13). |
 
 ### Functions
 
@@ -149,6 +158,10 @@
 | `EquivalenceCriterion.Validate` | `(c EquivalenceCriterion) Validate() error` | Error if Preserve or Ignore non-empty but Declaration empty (layer ordering: Layer 2 requires Layer 1 grounds). |
 | `PrintChain` | `func PrintChain(w io.Writer, cc ClassifiedChain) error` | Write human-readable classified chain to io.Writer. Includes steps with classifications, breaks with reasons, and criterion block when non-zero. |
 | `PrintChainJSON` | `func PrintChainJSON(w io.Writer, cc ClassifiedChain) error` | Export `ClassifiedChain` as JSON to io.Writer. Criterion key omitted entirely when zero (pointer + omitempty). |
+| `SummariseShadow` | `func SummariseShadow(g MeshGraph) ShadowSummary` | Read `g.Cut.ShadowElements`; count total shadowed, count by ShadowReason, count SeenFrom per excluded observer; return self-contained summary (M13). |
+| `PrintShadowSummary` | `func PrintShadowSummary(w io.Writer, s ShadowSummary) error` | Write shadow report to io.Writer. Observer position, shadow count by reason, SeenFrom counts descending, element list. Includes "No shadow" path when no elements shadowed (M13). |
+| `AnalyseGaps` | `func AnalyseGaps(g1, g2 MeshGraph) ObserverGap` | Compare node sets of two pre-articulated graphs; partition names into OnlyInA, OnlyInB, InBoth; retain both Cuts. Does not re-articulate (M13). |
+| `PrintObserverGap` | `func PrintObserverGap(w io.Writer, gap ObserverGap) error` | Write observer-gap report to io.Writer. Names both positions, three-way partition with element lists, "No gap" message when identical; neither position treated as authoritative (M13). |
 
 ## Package: persist
 
@@ -192,7 +205,7 @@ None (persist carries no domain types; wraps graph types).
 
 | File | Contains |
 |------|----------|
-| `main.go` | CLI entry point: subcommand dispatcher, helper types and functions. Includes `cmdDraft`, `cmdPromote` (M11), `cmdRearticulate`, `cmdLineage` (M12) handlers. |
+| `main.go` | CLI entry point: subcommand dispatcher, helper types and functions. Includes `cmdDraft`, `cmdPromote` (M11), `cmdRearticulate`, `cmdLineage` (M12), `cmdShadow`, `cmdGaps` (M13) handlers. |
 | `main_test.go` | Tests: all subcommands, flag parsing, file output, error handling, criterion file loading, draft/promote pipeline (M11). |
 
 ### Types
@@ -210,7 +223,7 @@ None (persist carries no domain types; wraps graph types).
 | `parseTimeFlag` | `func parseTimeFlag(name, value string) (time.Time, error)` | Parse RFC3339 string to time.Time with contextual error message naming the flag. |
 | `parseTimeWindow` | `func parseTimeWindow(fromName, fromStr, toName, toStr string) (graph.TimeWindow, error)` | Parse two RFC3339 strings (one or both may be empty) into a TimeWindow. Validates only when both bounds are set. |
 | `main` | `func main()` | Entry point. Calls `run(os.Stdout, os.Args[1:])` and exits non-zero on error. |
-| `run` | `func run(w io.Writer, args []string) error` | Command dispatcher. Parses args to identify subcommand and flags; routes to `cmdSummarize()`, `cmdValidate()`, `cmdArticulate()`, `cmdDiff()`, `cmdFollow()`, `cmdDraft()`, `cmdPromote()`, `cmdRearticulate()`, or `cmdLineage()`. |
+| `run` | `func run(w io.Writer, args []string) error` | Command dispatcher. Parses args to identify subcommand and flags; routes to `cmdSummarize()`, `cmdValidate()`, `cmdArticulate()`, `cmdDiff()`, `cmdFollow()`, `cmdDraft()`, `cmdPromote()`, `cmdRearticulate()`, `cmdLineage()`, `cmdShadow()`, or `cmdGaps()`. |
 | `cmdSummarize` | `func cmdSummarize(w io.Writer, args []string) error` | Subcommand: Load traces, compute mesh summary, print via `loader.PrintSummary()`. Usage: `meshant summarize <file>`. |
 | `cmdValidate` | `func cmdValidate(w io.Writer, args []string) error` | Subcommand: Load and validate traces. Reports success message or errors. Usage: `meshant validate <file>`. |
 | `cmdArticulate` | `func cmdArticulate(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut with `--observer` (repeatable), `--tag` (repeatable, any-match), `--from`, `--to` (RFC3339), `--format text\|json\|dot\|mermaid`, `--output <file>`. |
@@ -220,6 +233,8 @@ None (persist carries no domain types; wraps graph types).
 | `cmdPromote` | `func cmdPromote(w io.Writer, args []string) error` | Subcommand: Load TraceDraft JSON via `loader.LoadDrafts()`, call `IsPromotable()` on each, promote qualifying drafts to canonical Traces (each tagged with `TagValueDraft`), write promoted Trace JSON, report promotion summary naming failures (M11). `--output <file>`. |
 | `cmdRearticulate` | `func cmdRearticulate(w io.Writer, args []string) error` | Subcommand: Load TraceDraft JSON, produce skeleton JSON array — for each draft: `source_span` copied verbatim, `derived_from` set to original ID, all content fields blank, `extraction_stage:"reviewed"`. Flags: `--id <id>` (single draft only), `--output <file>` (M12). |
 | `cmdLineage` | `func cmdLineage(w io.Writer, args []string) error` | Subcommand: Load TraceDraft JSON, walk DerivedFrom links, render positional reading sequences as indented trees. Anchors (drafts with no DerivedFrom) are sequence roots. Cycle detection required (DFS grey-set). Flags: `--id <id>` (single chain), `--format text\|json` (M12). |
+| `cmdShadow` | `func cmdShadow(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut, print shadow summary via `graph.SummariseShadow()` + `PrintShadowSummary()`. Flags: `--observer` (repeatable, required), `--tag` (repeatable), `--from`, `--to` (RFC3339), `--output <file>` (M13). |
+| `cmdGaps` | `func cmdGaps(w io.Writer, args []string) error` | Subcommand: Load traces, articulate two cuts from the same file, compare node sets via `graph.AnalyseGaps()`, print observer-gap report via `PrintObserverGap()`. Flags: `--observer-a`, `--observer-b` (repeatable, both required), per-side `--tag-a/b`, `--from-a/b`, `--to-a/b` (RFC3339), `--output <file>` (M13). |
 | `loadCriterionFile` | `func loadCriterionFile(path string) (graph.EquivalenceCriterion, error)` | Load, decode, and validate an EquivalenceCriterion from a JSON file. Uses `DisallowUnknownFields()` for precision. Zero-value criterion is a hard error. Returns validated criterion or descriptive error. |
 | `outputWriter` | `func outputWriter(w io.Writer, outputPath string) (io.Writer, error)` | Return file writer if `--output` is set, otherwise stdout. |
 | `confirmOutput` | `func confirmOutput(w io.Writer, outputPath string) error` | Print "wrote <path>" confirmation to stdout when file output is used. |
@@ -235,6 +250,7 @@ None (persist carries no domain types; wraps graph types).
 - **File output**: `--output <file>` writes to file instead of stdout (with deferred close for safety)
 - **Ingestion pipeline** (M11): `draft` command ingests LLM extraction JSON and produces TraceDraft records; `promote` command converts promotable TraceDraft records to canonical Traces (tagged with `draft` provenance signal)
 - **Re-articulation pipeline** (M12): `rearticulate` command produces critique skeletons (SourceSpan + DerivedFrom set, all content fields blank); `lineage` command walks DerivedFrom links and renders positional reading sequences as CLI output
+- **Shadow analysis** (M13): `shadow` subcommand summarises shadowed elements from a cut; `gaps` subcommand compares element visibility between two observer positions; neither position is authoritative
 - **Binary installation**: `go install ./cmd/meshant` produces `meshant` binary at $GOPATH/bin; used in Dockerfile at `/usr/local/bin/meshant`
 
 ## Cross-Package Relationships
@@ -345,6 +361,14 @@ cmd/demo/
 | Promote draft to canonical Trace | `schema/tracedraft.go` → `TraceDraft.Promote()` |
 | Produce critique skeleton from draft | `cmd/meshant/main.go` → `cmdRearticulate()` |
 | Walk DerivedFrom lineage chain | `cmd/meshant/main.go` → `cmdLineage()` |
+| Traverse DerivedFrom chain programmatically | `loader/draftchain.go` → `FollowDraftChain()` |
+| Classify draft chain steps | `loader/draftchain.go` → `ClassifyDraftChain()` |
+| Summarise shadow elements from a graph | `graph/shadow.go` → `SummariseShadow()` |
+| Print shadow summary | `graph/shadow.go` → `PrintShadowSummary()` |
+| Compare two graph node sets | `graph/gaps.go` → `AnalyseGaps()` |
+| Print observer-gap report | `graph/gaps.go` → `PrintObserverGap()` |
+| Shadow summary via CLI | `cmd/meshant/main.go` → `cmdShadow()` |
+| Observer-gap report via CLI | `cmd/meshant/main.go` → `cmdGaps()` |
 | Read critique prompt contract | `data/prompts/critique_pass.md` |
 | Run minimal demo | `cmd/demo/main.go` → `run()` |
 
@@ -419,6 +443,14 @@ cmd/demo/
 - **cmdLineage is a chain reader, not a diff tool**: renders structure (which reading followed which, at what stage, by whom); comparing readings in a chain is the analyst's job
 - **Critique prompt template as methodological constraint**: `data/prompts/critique_pass.md` is the extraction contract that makes re-articulation ANT-faithful; the CLI enforces structural constraints, the template enforces interpretive constraints
 
+### Shadow Analysis (M13)
+- **Shadow is a cut decision**: `SummariseShadow` reads `Cut.ShadowElements` (already computed by Articulate); "shadowed" not "missing"
+- **ObserverGap is composable**: `AnalyseGaps` takes two pre-articulated `MeshGraph` values; does not re-articulate
+- **Both cuts retained**: `ObserverGap.CutA` and `CutB` preserved so any report is self-situated
+- **FollowDraftChain mirrors FollowTranslation**: same first-match, cycle-detection, and empty-if-not-found semantics
+- **CriterionRef is string-only**: stores criterion `Name` (not the struct) to prevent `schema`→`graph` import cycle
+- **DraftStepKind is v1 provisional**: mirrors StepKind; will be revisited when criteria govern draft chains
+
 ### Ingestion Pipeline (M11)
 - **TraceDraft** is a first-class analytical object, not a halfway house to Trace
 - **SourceSpan** is the only required field; minimal record carrying verbatim source text without forcing resolution
@@ -482,7 +514,8 @@ cmd/demo/
 - `docs/decisions/translation-chain-v2.md` — Translation chain traversal, classification heuristics, first-match branching (M10.5)
 - `docs/decisions/equivalence-criterion-v1.md` — Equivalence criterion design, three-layer model, v1 implicit criterion, second-order shadow (M10.5+)
 - `docs/decisions/tracedraft-v2.md` — TraceDraft design, ingestion pipeline as analytical object, source span as ground truth, promotion criterion, provenance chain (M11)
-- `docs/decisions/rearticulation-v2.md` — Re-articulation as cut not correction, SourceSpan invariant, blank scaffold as correct output, DerivedFrom positional vocabulary, cmdLineage as first-class CLI output, E3/E14 as demonstration material (M12)
+- `docs/decisions/rearticulation-v1.md` — Re-articulation as cut not correction, SourceSpan invariant, blank scaffold as correct output, DerivedFrom positional vocabulary, cmdLineage as first-class CLI output, E3/E14 as demonstration material (M12)
+- `docs/decisions/shadow-analysis-v1.md` — Shadow as cut decision, ObserverGap composability, FollowDraftChain design, CriterionRef as citation metadata, DraftStepKind v1 heuristics, shadow/gaps CLI-first design (M13)
 - `docs/authoring-traces.md` — Trace authoring guide with worked example (M9)
 - `docs/reviews/review_philosophical_m9.md` — Philosophical review, M9 violations and fixes
 
@@ -507,4 +540,8 @@ cmd/demo/
 - `graph/incident_e2e_test.go` — E2E tests using incident response dataset
 - `persist/persist_test.go` — tests for file I/O functions
 - `cmd/demo/main_test.go` — E2E test
-- `cmd/meshant/main_test.go` — tests covering all CLI subcommands including follow, draft, promote (M11), rearticulate, lineage (M12), flag parsing, file output, error handling; 659 total tests, 88.2% cmd/meshant coverage
+- `graph/shadow_test.go` — 10 tests for SummariseShadow and PrintShadowSummary (M13)
+- `graph/gaps_test.go` — 9 tests for AnalyseGaps and PrintObserverGap (M13)
+- `loader/draftchain_test.go` — 11 tests for FollowDraftChain and ClassifyDraftChain (M13)
+- `schema/tracedraft_test.go` — includes tests for CriterionRef (M13) and IntentionallyBlank (M12.5)
+- `cmd/meshant/main_test.go` — tests covering all CLI subcommands including follow, draft, promote (M11), rearticulate, lineage (M12), shadow, gaps (M13), flag parsing, file output, error handling

--- a/docs/decisions/shadow-analysis-v1.md
+++ b/docs/decisions/shadow-analysis-v1.md
@@ -1,0 +1,187 @@
+# Decision Record: Shadow Analysis v1
+
+**Date:** 2026-03-17
+**Status:** Active
+**Milestone:** M13 — Shadow analysis + observer-gap + ingestion deepening
+**Packages:** `meshant/graph` (shadow.go, gaps.go), `meshant/loader` (draftchain.go), `meshant/schema` (tracedraft.go), `meshant/cmd/meshant` (shadow, gaps subcommands)
+**Related:** `docs/decisions/articulation-v2.md`, `docs/decisions/tracedraft-v2.md`, `docs/decisions/equivalence-criterion-v1.md`
+
+---
+
+## What was decided
+
+1. **Shadow is a cut decision, not missing data**
+2. **ObserverGap takes pre-articulated graphs — the operation is composable, not re-articulating**
+3. **FollowDraftChain mirrors FollowTranslation — derivation chains are first-class analytical objects**
+4. **CriterionRef is citation metadata — does not affect validation, promotability, or promotion**
+5. **DraftStepKind heuristics mirror StepKind — content change determines classification**
+6. **shadow and gaps are CLI-first — articulation is done by the subcommand, not the caller**
+
+---
+
+## Context
+
+M12 introduced the critique pipeline: re-articulation as a cut, DerivedFrom as positional vocabulary,
+`cmdLineage` for reading the chain. But the analytical surface of the graph package remained primarily
+about structure — what is there — rather than position — what is visible from here.
+
+M13 opens the shadow as a first-class analytical object. Shadow analysis (`SummariseShadow`) makes
+the cut's consequences visible: how many elements are shadowed, by what reason, from which positions.
+ObserverGap (`AnalyseGaps`) compares two cuts directly, producing a three-way partition without
+re-articulating.
+
+Simultaneously, M13 deepens the ingestion pipeline: `FollowDraftChain` makes the DerivedFrom chain
+traversable at the loader level (mirroring `FollowTranslation` at the graph level), and `CriterionRef`
+names which EquivalenceCriterion governed a critique skeleton.
+
+---
+
+## Decision 1: Shadow is a cut decision, not missing data
+
+`SummariseShadow` reads `MeshGraph.Cut.ShadowElements` — elements visible to excluded observers, not
+included in the current articulation. These elements are not absent or unknown; they were deliberately
+excluded when the cut was made.
+
+All output language uses "shadowed" rather than "missing" or "absent". `ShadowSummary.ByReason` names
+*why* elements were shadowed (observer position, tag filter, or time window) — three causes, each
+corresponding to one of the three cut axes. `SeenFromCounts` names *who else* can see the shadowed
+elements.
+
+The test `TestSummariseShadow_ByReason` verifies that `ShadowReasonObserver` appears in `ByReason`
+when elements are excluded by observer position — the most common shadow cause in the evacuation dataset.
+
+This language commitment applies in `PrintShadowSummary`, `SummariseShadow`, and all documentation.
+The word "missing" does not appear in shadow-analysis output or code comments.
+
+---
+
+## Decision 2: ObserverGap takes pre-articulated graphs
+
+`AnalyseGaps(g1, g2 MeshGraph) ObserverGap` takes two already-articulated `MeshGraph` values.
+
+This is the composability decision: the caller is responsible for articulation (including choosing
+observer positions, time windows, and tag filters). `AnalyseGaps` only reads `g1.Nodes` and `g2.Nodes`
+plus both `Cut` fields. It does not load traces, does not call `Articulate()`, and does not impose
+a time window.
+
+The alternative — `AnalyseGaps(traces, optsA, optsB)` — would be convenient but would hide
+articulation inside the comparison function, making it undebuggable and non-composable. The caller
+may want to inspect g1 and g2 independently before comparing them. Taking pre-articulated values
+preserves that option.
+
+`cmdGaps` does the articulation (two calls to `graph.Articulate`) before calling `AnalyseGaps`.
+This is the correct place for it: the CLI is the convenient layer; the library function is the
+composable layer.
+
+Each `ObserverGap` retains both `Cut` fields (`CutA`, `CutB`) so the gap report is self-situated:
+a comparison without its positions is uninterpretable. `PrintObserverGap` always names both positions.
+
+---
+
+## Decision 3: FollowDraftChain mirrors FollowTranslation
+
+`FollowDraftChain(drafts []TraceDraft, from string) []TraceDraft` returns the chain of drafts in
+derivation order starting from the draft with id `from`. It mirrors `FollowTranslation` in the
+graph package: a traversal that produces an ordered sequence, stopping at leaves.
+
+Implementation uses a children map (parent ID → []child IDs) and a visited set for cycle detection.
+The first unvisited child at each step is followed; siblings beyond the first are not followed
+(consistent with first-match branching in FollowTranslation). An empty slice is returned if `from`
+is not found — not an error — because the caller may be probing membership before traversal.
+
+`ClassifyDraftChain(chain []TraceDraft) []DraftStepClassification` applies heuristic classification
+to each consecutive pair. The heuristics are:
+
+- `DraftTranslation` — content fields changed AND ExtractionStage changed (framing + position)
+- `DraftMediator` — content fields changed, stage unchanged (reformulated framing, same pipeline position)
+- `DraftIntermediary` — only UncertaintyNote added (relayed faithfully with one annotation)
+
+These mirror `StepKind` from the graph package (`StepTranslation`, `StepMediator`, `StepIntermediary`).
+The heuristics are labelled v1 and acknowledged as provisional — the same framing used for
+`ClassifyChain`.
+
+---
+
+## Decision 4: CriterionRef is citation metadata
+
+`TraceDraft.CriterionRef string (json:"criterion_ref,omitempty")` names the EquivalenceCriterion
+under which a draft was produced or reviewed. It carries the criterion's `Name` field as a string.
+
+CriterionRef is deliberately metadata-only:
+- `Validate()` does not require it
+- `IsPromotable()` does not check it
+- `Promote()` does not copy it to the canonical Trace (it belongs to the draft pipeline, not the
+  canonical record)
+
+The import-cycle prevention is structural: `schema` cannot import `graph`. Storing the criterion
+`Name` as a string (not the `EquivalenceCriterion` struct) avoids a new dependency. The criterion
+file is loaded in `cmd/meshant/main.go` (which already imports both packages) and its `Name` is
+passed to `CriterionRef` as a plain string.
+
+The `--criterion-file` flag on `cmdRearticulate` reuses `loadCriterionFile()` already defined for
+`cmdFollow`. Setting `CriterionRef` on every skeleton makes critique skeletons self-situated: the
+reader can trace which criterion governed the critique pass.
+
+When `--criterion-file` is absent, `CriterionRef` is empty. Empty is correct: a skeleton produced
+without a named criterion is honest about that absence.
+
+---
+
+## Decision 5: DraftStepKind heuristics are provisional (v1)
+
+`DraftStepKind` has three values: `DraftIntermediary`, `DraftMediator`, `DraftTranslation`.
+The heuristics that assign them are acknowledged as v1 and will be revisited when criteria are
+applied to draft chains.
+
+`classifyDraftStep` checks content fields (WhatChanged, Source, Target, Mediation, Observer, Tags)
+and ExtractionStage changes. The ordering — Translation > Mediator > Intermediary — follows the
+same priority logic as `classifyChainStep`: the most transformative kind wins when multiple
+conditions are met.
+
+`Reason` strings in `DraftStepClassification` are human-readable justifications of the heuristic,
+not machine-parseable codes. This mirrors `StepClassification.Reason` in the graph package.
+
+---
+
+## Decision 6: shadow and gaps are CLI-first
+
+`cmdShadow` and `cmdGaps` follow the existing CLI flag patterns exactly:
+- `stringSliceFlag` for repeatable observer flags
+- `parseTimeWindow` for RFC3339 time boundaries
+- `outputWriter` / `confirmOutput` for optional file output
+- No format flag (shadow and gap reports are text-only in v1)
+
+Neither subcommand exposes a format flag in v1. The reports have natural tabular structure that
+benefits from text rendering; JSON export of `ShadowSummary` and `ObserverGap` is deferred to a
+future milestone if needed.
+
+`cmdShadow` requires `--observer` (at least one). A shadow summary without a named observer
+position would not be self-situated — the report would not name what the cut cannot see from where.
+`cmdGaps` requires both `--observer-a` and `--observer-b`.
+
+---
+
+## What M13 does NOT do
+
+- **Shadow mode for `cmdArticulate`**: shadow summary is a separate subcommand, not a mode flag on
+  articulate; keeps each command focused on one operation
+- **Interactive chain review**: `FollowDraftChain` is a library function; no CLI subcommand wraps
+  it in v1 — the lineage reader (`cmdLineage`) already provides chain output
+- **Criterion-driven draft classification**: `ClassifyDraftChain` uses v1 heuristics; criterion
+  application to draft chains is deferred
+- **Layer 3 comparison**: EquivalenceCriterion's comparison function (deferred since M10.5+) remains
+  deferred; CriterionRef is annotation only
+- **JSON export for shadow/gap**: text output only in v1
+
+---
+
+## Related
+
+- `docs/decisions/articulation-v2.md` — observer position as primary cut axis; shadow mandatory
+- `docs/decisions/translation-chain-v2.md` — FollowTranslation and ClassifyChain patterns mirrored
+  by FollowDraftChain and ClassifyDraftChain
+- `docs/decisions/equivalence-criterion-v1.md` — CriterionRef stores criterion.Name; import cycle
+  prevention via string, not struct
+- `docs/decisions/tracedraft-v2.md` — DerivedFrom as positional vocabulary; SourceSpan as invariant
+- `docs/decisions/rearticulation-v1.md` — critique skeleton design; IntentionallyBlank (M12.5)
+- `tasks/todo.md` — M13 section

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -533,6 +533,74 @@ TraceDraft of the same SourceSpan, linked by DerivedFrom. A second cut, not a co
 
 ---
 
+## M12.5 — IntentionallyBlank on TraceDraft
+
+**Status:** Complete
+**Parent issue:** #64
+**PR:** #67 (`64-intentionally-blank`)
+
+Adds `IntentionallyBlank []string` to `TraceDraft`. Blank content fields on critique skeletons
+are now structurally declared: the difference between "never extracted" and "deliberately not
+extracted" is a named distinction, not an absence.
+
+### Tasks
+
+- [x] **M12.5.1 — IntentionallyBlank field** — PR #67
+  - `IntentionallyBlank []string \`json:"intentionally_blank,omitempty"\`` on `TraceDraft`
+  - `cmdRearticulate` sets `IntentionallyBlank` on every skeleton
+  - `DraftSummary.WithIntentionallyBlank int` — count of drafts with at least one intentionally blank field
+  - `PrintDraftSummary` shows count line
+  - Tests: tracedraft_test.go (3 tests), draftloader_test.go (3 tests), main_test.go (1 test)
+
+---
+
+## M13 — Shadow Analysis + Observer Gap + Ingestion Deepening
+
+**Status:** Complete
+**Parent issue:** #52
+**Branch base:** `develop`
+
+Six issues deepening the analytical core and ingestion pipeline. Shadow and observer-gap make
+positional incompleteness into first-class analytical objects. FollowDraftChain and CriterionRef
+deepen the ingestion pipeline.
+
+### Tasks
+
+- [x] **M13.1 — FollowDraftChain** — PR #70 (`68-follow-draft-chain`) — Issue #68
+  - `meshant/loader/draftchain.go` — `FollowDraftChain`, `ClassifyDraftChain`, `DraftStepKind`, `DraftStepClassification`
+  - `meshant/loader/draftchain_test.go` — 11 tests
+  - v1 heuristics: DraftIntermediary, DraftMediator, DraftTranslation
+
+- [x] **M13.2 — CriterionRef on TraceDraft** — PR #71 (`69-criterion-ref`) — Issue #69
+  - `CriterionRef string \`json:"criterion_ref,omitempty"\`` on `TraceDraft`
+  - `--criterion-file <path>` flag on `cmdRearticulate`; sets CriterionRef on each skeleton
+  - `DraftSummary.WithCriterionRef int`; `PrintDraftSummary` shows count
+  - Tests: tracedraft_test.go (5), draftloader_test.go (2), main_test.go (3)
+
+- [x] **M13.3 — ShadowSummary** — PR #72 (`13-shadow-summary`) — Issue #13
+  - `meshant/graph/shadow.go` — `SummariseShadow`, `PrintShadowSummary`, `ShadowSummary`
+  - `meshant/graph/shadow_test.go` — 10 tests
+  - Shadow language throughout: "shadowed" not "missing"
+
+- [x] **M13.4 — ObserverGapReport** — PR #73 (`14-observer-gap`) — Issue #14
+  - `meshant/graph/gaps.go` — `AnalyseGaps`, `PrintObserverGap`, `ObserverGap`
+  - `meshant/graph/gaps_test.go` — 9 tests
+  - Takes pre-articulated MeshGraph values; composable, not re-articulating
+
+- [x] **M13.5 — CLI shadow + gaps subcommands** — PR #74 (`15-cli-shadow-gaps`) — Issue #15
+  - `meshant shadow --observer <pos> [flags] <traces.json>`
+  - `meshant gaps --observer-a <pos> --observer-b <pos> [flags] <traces.json>`
+  - 8 tests (shadow), 9 tests (gaps) in main_test.go
+
+- [x] **M13.6 — Decision record + codemap** — Issue #16
+  - `docs/decisions/shadow-analysis-v1.md` — 6 decisions for M13
+  - `docs/CODEMAPS/meshant.md` — updated with new files, types, functions
+  - `tasks/todo.md` — M13 section added, all tasks marked complete
+
+`go test ./...` green; `go vet ./...` clean.
+
+---
+
 ## Post-v1.0.0 — Open Horizon
 
 Informed by v1.0.0 review (`docs/reviews/release_v1_review_13-mar-26.md`) and earlier
@@ -545,7 +613,7 @@ These deepen the analytical core — deferred across earlier milestones:
 
 - [x] **Tag-filter cut axis** — third cut axis alongside observer and time-window (completed in M10)
 - [x] **GraphDiff DOT / Mermaid export** — `PrintDiffDOT`, `PrintDiffMermaid` (completed in M10)
-- [ ] **Shadow analysis operations** — shadow summary, shadow-first mode, unstable-boundary reports
+- [x] **Shadow analysis operations** — shadow summary, observer-gap report, shadow/gaps CLI subcommands (completed in M13)
 - [ ] **Re-articulation** — re-cutting the same dataset; showing how one articulation provokes another
 
 ### Authoring support (Layer 1)
@@ -561,7 +629,7 @@ The most important next frontier — the direct interface with the user:
 
 How outputs become actionable:
 
-- [ ] **Interpretive outputs** — observer-gap report, bottleneck note, shadow summary, re-articulation suggestion, incident narrative draft
+- [x] **Interpretive outputs (partial)** — observer-gap report and shadow summary completed in M13; bottleneck note, re-articulation suggestion, incident narrative draft remain
 - [ ] **More real-world examples** — validate authoring conventions and interpretation patterns across domains
 
 ### Constraints


### PR DESCRIPTION
## Summary

- `docs/decisions/shadow-analysis-v1.md` — 6 design decisions for M13: shadow as cut decision (not missing data), ObserverGap composability, FollowDraftChain mirroring FollowTranslation, CriterionRef as citation metadata, DraftStepKind v1 heuristics, CLI-first shadow/gaps
- `docs/CODEMAPS/meshant.md` — updated with all new M13 files (shadow.go, gaps.go, draftchain.go), types (ShadowSummary, ObserverGap, DraftStepKind, DraftStepClassification), functions, cmd/meshant section, design patterns section, Where to Find Things
- `tasks/todo.md` — M12.5 and M13 sections added and marked complete; shadow analysis operations and interpretive outputs (partial) marked done in open horizon

## No code changes

This PR contains only documentation. All implementations are in PRs #70–#74.

Closes #16