### PR TITLE
A.6: Thread A decision record + codemap (#93)

### DIFF
--- a/docs/CODEMAPS/meshant.md
+++ b/docs/CODEMAPS/meshant.md
@@ -13,7 +13,7 @@
 | `loader` | Load traces from JSON, summarize datasets, print summaries. |
 | `graph` | Articulate graphs, compute diffs, identify graphs as actors, reflexive tracing, follow translation chains, classify chains, shadow analysis, observer-gap analysis, bottleneck analysis, re-articulation suggestions, narrative drafts, export to JSON/DOT/Mermaid. |
 | `persist` | Read and write graphs to JSON files. |
-| `review` | Ambiguity detection and terminal rendering for the interactive review session (Thread A). |
+| `review` | Ambiguity detection, terminal rendering, and interactive accept/edit/skip/quit session for TraceDraft records (Thread A). |
 | `cmd/demo` | Minimal demonstration: two observer-position cuts on evacuation dataset. |
 | `cmd/meshant` | CLI entry point: `summarize`, `validate`, `articulate`, `diff`, `follow`, `draft`, `promote`, `rearticulate`, `lineage`, `shadow`, `gaps`, `bottleneck`, `review` subcommands. `articulate` supports `--narrative` flag; `gaps` supports `--suggest` flag. `review` is the only interactive subcommand (reads from stdin). |
 
@@ -205,7 +205,8 @@ None (persist carries no domain types; wraps graph types).
 | File | Contains |
 |------|----------|
 | `ambiguity.go` | `AmbiguityWarning` struct; `DetectAmbiguities` function. |
-| `render.go` | `RenderDraft`, `RenderAmbiguities`; helpers `valueOrEmpty`, `sliceOrEmpty`. |
+| `render.go` | `RenderDraft`, `RenderAmbiguities`, `RenderChain`; helpers `valueOrEmpty`, `sliceOrEmpty`, `truncateString`. |
+| `session.go` | `RunReviewSession`, `deriveAccepted`, `deriveEdited`, `runEditFlow`, `parseCommaSeparated`, `filterReviewable`, `cloneStrings`; interactive session loop and derivation logic (Thread A.3/A.4). |
 
 ### Types
 
@@ -249,7 +250,7 @@ None (persist carries no domain types; wraps graph types).
 
 | File | Contains |
 |------|----------|
-| `main.go` | CLI entry point: subcommand dispatcher, helper types and functions. Includes `cmdDraft`, `cmdPromote` (M11), `cmdRearticulate`, `cmdLineage` (M12), `cmdShadow`, `cmdGaps` (M13), `cmdBottleneck` (B.1) handlers. |
+| `main.go` | CLI entry point: subcommand dispatcher, helper types and functions. Includes `cmdDraft`, `cmdPromote` (M11), `cmdRearticulate`, `cmdLineage` (M12), `cmdShadow`, `cmdGaps` (M13), `cmdBottleneck` (B.1), `cmdReview` (A.5) handlers. (~1720 lines — pre-existing size debt, tracked for future per-command file split.) |
 | `main_test.go` | Tests: all subcommands, flag parsing, file output, error handling, criterion file loading, draft/promote pipeline (M11). |
 
 ### Types
@@ -267,7 +268,7 @@ None (persist carries no domain types; wraps graph types).
 | `parseTimeFlag` | `func parseTimeFlag(name, value string) (time.Time, error)` | Parse RFC3339 string to time.Time with contextual error message naming the flag. |
 | `parseTimeWindow` | `func parseTimeWindow(fromName, fromStr, toName, toStr string) (graph.TimeWindow, error)` | Parse two RFC3339 strings (one or both may be empty) into a TimeWindow. Validates only when both bounds are set. |
 | `main` | `func main()` | Entry point. Calls `run(os.Stdout, os.Args[1:])` and exits non-zero on error. |
-| `run` | `func run(w io.Writer, args []string) error` | Command dispatcher. Parses args to identify subcommand and flags; routes to `cmdSummarize()`, `cmdValidate()`, `cmdArticulate()`, `cmdDiff()`, `cmdFollow()`, `cmdDraft()`, `cmdPromote()`, `cmdRearticulate()`, `cmdLineage()`, `cmdShadow()`, or `cmdGaps()`. |
+| `run` | `func run(w io.Writer, args []string) error` | Command dispatcher. Parses args to identify subcommand and flags; routes to `cmdSummarize()`, `cmdValidate()`, `cmdArticulate()`, `cmdDiff()`, `cmdFollow()`, `cmdDraft()`, `cmdPromote()`, `cmdRearticulate()`, `cmdLineage()`, `cmdShadow()`, `cmdGaps()`, `cmdBottleneck()`, or `cmdReview()`. For the `review` case, passes `os.Stdin` as the reader to `cmdReview`. |
 | `cmdSummarize` | `func cmdSummarize(w io.Writer, args []string) error` | Subcommand: Load traces, compute mesh summary, print via `loader.PrintSummary()`. Usage: `meshant summarize <file>`. |
 | `cmdValidate` | `func cmdValidate(w io.Writer, args []string) error` | Subcommand: Load and validate traces. Reports success message or errors. Usage: `meshant validate <file>`. |
 | `cmdArticulate` | `func cmdArticulate(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut with `--observer` (repeatable), `--tag` (repeatable, any-match), `--from`, `--to` (RFC3339), `--format text\|json\|dot\|mermaid`, `--output <file>`. Optional `--narrative` flag appends a positioned narrative draft (text format only, skipped for JSON/DOT/Mermaid). |
@@ -280,6 +281,7 @@ None (persist carries no domain types; wraps graph types).
 | `cmdShadow` | `func cmdShadow(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut, print shadow summary via `graph.SummariseShadow()` + `PrintShadowSummary()`. Flags: `--observer` (repeatable, required), `--tag` (repeatable), `--from`, `--to` (RFC3339), `--output <file>` (M13). |
 | `cmdGaps` | `func cmdGaps(w io.Writer, args []string) error` | Subcommand: Load traces, articulate two cuts, compare node sets via `graph.AnalyseGaps()`, print gap report. Optionally appends re-articulation suggestions via `--suggest`. Flags: `--observer-a`, `--observer-b` (required), per-side `--tag-a/b`, `--from-a/b`, `--to-a/b`, `--suggest` (bool), `--output` (M13, B.2). |
 | `cmdBottleneck` | `func cmdBottleneck(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut, identify bottlenecks via `graph.IdentifyBottlenecks()`, print notes via `PrintBottleneckNotes()`. Flags: `--observer` (optional), `--tag`, `--from`, `--to`, `--output` (B.1). |
+| `cmdReview` | `func cmdReview(w io.Writer, in io.Reader, args []string) error` | Subcommand: Load TraceDraft JSON, run interactive accept/edit/skip/quit session via `review.RunReviewSession()`. Only interactive subcommand — signature diverges from all other `cmd*` functions by accepting `in io.Reader` for stdin injection (testability). Interactive prompts go to `os.Stderr`; JSON output and summary go to `w`. Flags: `--output <file>` (A.5). |
 | `loadCriterionFile` | `func loadCriterionFile(path string) (graph.EquivalenceCriterion, error)` | Load, decode, and validate an EquivalenceCriterion from a JSON file. Uses `DisallowUnknownFields()` for precision. Zero-value criterion is a hard error. Returns validated criterion or descriptive error. |
 | `outputWriter` | `func outputWriter(w io.Writer, outputPath string) (io.Writer, error)` | Return file writer if `--output` is set, otherwise stdout. |
 | `confirmOutput` | `func confirmOutput(w io.Writer, outputPath string) error` | Print "wrote <path>" confirmation to stdout when file output is used. |
@@ -292,7 +294,9 @@ None (persist carries no domain types; wraps graph types).
 - **Flag parsing**: Uses stdlib `flag.FlagSet` for subcommand isolation; `stringSliceFlag` enables repeatable `--observer` flags without comma-separation
 - **Time handling**: RFC3339 timestamps throughout; `parseTimeFlag()` and `parseTimeWindow()` provide clear error messages with formatting hints
 - **Format options**: `articulate` and `diff` both support text/json/dot/mermaid; `follow` supports text/json
-- **File output**: `--output <file>` writes to file instead of stdout (with deferred close for safety)
+- **File output**: `--output <file>` writes to file instead of stdout; `cmdReview` uses explicit `f.Close()` (not deferred) to surface write errors
+- **Interactive subcommand**: `cmdReview` is the only `cmd*` function that accepts `in io.Reader` — all other subcommands are non-interactive. `run()` passes `os.Stdin` for the review case only. If a second interactive subcommand is added, migrate to a `cmdContext` struct rather than adding more signature exceptions.
+- **Stderr/stdout separation**: `cmdReview` writes interactive prompts to `os.Stderr` and JSON output to `w` (stdout), enabling `meshant review file.json | jq .` and `--output` file routing without prompt contamination.
 - **Ingestion pipeline** (M11): `draft` command ingests LLM extraction JSON and produces TraceDraft records; `promote` command converts promotable TraceDraft records to canonical Traces (tagged with `draft` provenance signal)
 - **Re-articulation pipeline** (M12): `rearticulate` command produces critique skeletons (SourceSpan + DerivedFrom set, all content fields blank); `lineage` command walks DerivedFrom links and renders positional reading sequences as CLI output
 - **Shadow analysis** (M13): `shadow` subcommand summarises shadowed elements from a cut; `gaps` subcommand compares element visibility between two observer positions; neither position is authoritative
@@ -581,6 +585,7 @@ cmd/demo/
 - `docs/decisions/tracedraft-v2.md` — TraceDraft design, ingestion pipeline as analytical object, source span as ground truth, promotion criterion, provenance chain (M11)
 - `docs/decisions/rearticulation-v1.md` — Re-articulation as cut not correction, SourceSpan invariant, blank scaffold as correct output, DerivedFrom positional vocabulary, cmdLineage as first-class CLI output, E3/E14 as demonstration material (M12)
 - `docs/decisions/shadow-analysis-v1.md` — Shadow as cut decision, ObserverGap composability, FollowDraftChain design, CriterionRef as citation metadata, DraftStepKind v1 heuristics, shadow/gaps CLI-first design (M13)
+- `docs/decisions/interactive-review-v1.md` — Interactive review CLI design: session as cut, render-as-string, ExtractedBy sameness, provenance/content partition, stdin/stderr separation, main.go size debt (Thread A)
 - `docs/authoring-traces.md` — Trace authoring guide with worked example (M9)
 - `docs/reviews/review_philosophical_m9.md` — Philosophical review, M9 violations and fixes
 

--- a/docs/decisions/interactive-review-v1.md
+++ b/docs/decisions/interactive-review-v1.md
@@ -1,0 +1,194 @@
+# Decision Record: Interactive Review CLI v1
+
+**Date:** 2026-03-19
+**Status:** Active
+**Milestone:** Thread A — Interactive Review CLI
+**Packages:** `meshant/review`, `meshant/cmd/meshant` (cmdReview)
+**Related:** `docs/decisions/tracedraft-v2.md`, `docs/decisions/cli-v2.md`, `tasks/plan_thread_a.md`
+
+---
+
+## What was decided
+
+1. **Render functions return string, not write to io.Writer** — `RenderDraft`, `RenderChain`, `RenderAmbiguities` return a composed string; the caller writes it where it needs to go.
+2. **ExtractedBy is "meshant-review" for both accept and edit** — the session apparatus is the actor regardless of whether content changed; the distinction between relay and transformation is recoverable from the chain.
+3. **Edit is one derivation step, not two** — edit-then-accept is a single cut producing one derived draft with no intermediate "edited-but-not-accepted" record.
+4. **filterReviewable fallback presents all drafts when no stage metadata exists** — epistemic absence of stage annotations is treated as a signal to present all drafts, not to reject all.
+5. **cmdReview has a different signature from all other cmd\* functions** — `cmdReview(w, in, args)` accepts an `io.Reader` for stdin; all other subcommands take only `(w, args)`.
+6. **Interactive prompts go to stderr; data goes to stdout** — `RunReviewSession` writes prompts to `os.Stderr`; accepted/edited draft JSON and the summary go to `w` (stdout), keeping stdout pipeable.
+7. **Provenance/content partition in deriveEdited** — SourceSpan, SourceDocRef, and IntentionallyBlank come from the parent (unchanged provenance); all content fields come from the reviewer's input.
+8. **main.go file size debt acknowledged, deferred** — `main.go` reached ~1720 lines during Thread A, exceeding the 800-line ceiling. No split was made in Thread A; the refactor is tracked as separate technical debt.
+
+---
+
+## Context
+
+The TraceDraft pipeline (Milestones 11–13, Thread B) produces `weak-draft` records from LLM extractions. These records carry provenance (`SourceSpan`, `ExtractedBy`, `ExtractionStage`) and uncertainty signals (`UncertaintyNote`, `IntentionallyBlank`), but they are not yet promotable to Traces usable for articulation. Between extraction and promotion there is a gap: a human pass that can refine, endorse, or skip records.
+
+Thread A closes this gap with a terminal review session: `meshant review <file>`. The reviewer sees each draft with its derivation chain and ambiguity warnings, then acts — accept (endorse as-is), edit (modify one or more content fields), skip (defer), or quit. Every acceptance and every edit produces a new derived `TraceDraft`, leaving the original intact. The session is a cut, not a correction pass.
+
+The review package is designed for composability. It imports `schema` and `loader`; it is itself imported only by `cmd/meshant`. No cycle. Session logic is independently testable with injected `io.Reader` / `io.Writer`. No external dependencies.
+
+This record documents the decisions made during Thread A that are not recoverable from the code alone. A different cut on this thread — a different reviewer reading the same pull requests — would surface different decisions. The eight decisions and five ANT tensions named here are those that surfaced through implementation, code review, and ANT-theorist review.
+
+---
+
+## Decision 1: Render functions return string, not write to io.Writer
+
+The thread plan sketched render functions with `io.Writer` parameters — each function would write directly to a terminal writer. In implementation, `RenderDraft`, `RenderChain`, and `RenderAmbiguities` were built as string-returning functions instead.
+
+The reason is composability. `RunReviewSession` calls all three in sequence for each draft, then writes to the session's `out io.Writer`. If each render function held its own writer, the session would need to thread the writer through three separate calls. Instead, it calls `fmt.Fprint(out, RenderChain(...))` and `fmt.Fprint(out, RenderDraft(...))` — the session owns the output, the render functions produce values.
+
+String-returning functions are also easier to test: the test inspects a return value rather than capturing a writer. And they are easier to compose: a future caller that wants to log render output, display it in a TUI, or write it to a file can do so without changing the render functions.
+
+This also preserves a separation between articulation (what to render) and commitment (where to send it). The render functions produce readings; the session decides their destination. This mirrors MeshAnt's broader principle that the apparatus should not foreclose how its outputs are used.
+
+The divergence from the plan was noted in the A.2 code review and accepted by the architect.
+
+---
+
+## Decision 2: ExtractedBy is "meshant-review" for both accept and edit
+
+`deriveAccepted` and `deriveEdited` both set `ExtractedBy: "meshant-review"`. Accept and edit are structurally different operations — accept is closer to an endorsement (content passes through unchanged), edit is closer to a transformation (content is modified) — but both produce the same `ExtractedBy` value.
+
+This reflects Principle 7 (generalised symmetry): the session apparatus is the actor, not the human at the keyboard. The human is part of the session assemblage, but the session is what performs the cut. `ExtractedBy` names the instrument, not the person.
+
+The alternative — different `ExtractedBy` values for accept vs edit (e.g., `"meshant-review:accepted"` vs `"meshant-review:edited"`) — was considered. It was rejected as premature classification (C1). The distinction between accept-as-relay and edit-as-transformation is an analytical claim that requires an equivalence criterion to make formally. Pre-classifying it in the data would commit MeshAnt to a theory of what endorsement vs transformation means before the framework has followed enough traces to warrant that theory.
+
+A downstream analyst can always recover the distinction: compare the derived draft's content fields against the parent's. If content changed, the session transformed; if content is identical, the session relayed. The information is present in the chain; it is not pre-classified.
+
+This tension was named by the ANT-theorist review of A.4 (Tension T2).
+
+---
+
+## Decision 3: Edit is one derivation step, not two
+
+When a reviewer chooses `[e]dit`, the session enters `runEditFlow` (collecting field edits), then calls `deriveEdited(parent, edited)`. One derived draft is produced. There is no intermediate "edited-but-not-accepted" draft that gets separately accepted.
+
+The alternative would be a two-step derivation: edit produces a draft at stage `"edited"`, and a separate accept step produces a draft at stage `"reviewed"`. This was explicitly rejected. It would create a phantom intermediary in the derivation chain — a draft that records the reviewer's edits but not their endorsement, as if editing and endorsing were separable acts. In practice they are not: a reviewer who edits a draft and commits the edit has both transformed and endorsed it in a single pass.
+
+The thread plan (D4) named this explicitly: "edit-then-accept is one derivation step, not two." The implementation honours that constraint.
+
+---
+
+## Decision 4: filterReviewable fallback presents all drafts when no stage metadata exists
+
+`filterReviewable` filters to `ExtractionStage == "weak-draft"` records. But if no draft in the input set has any `ExtractionStage` set, the function presents all drafts — the full slice becomes the review queue.
+
+This fallback handles legacy datasets produced before stage metadata was introduced. Without it, a legacy dataset would silently produce an empty review queue, and the reviewer would see "no drafts to review" for a file full of unreviewed material.
+
+The fallback is itself a cut: it converts the epistemic absence of stage annotations into the operational decision to review everything. This is not a neutral act. An alternative would be to require stage metadata and return an error when none is present. That alternative was rejected as too strict for a tool that should accommodate real-world data in various states of completion.
+
+The ANT-theorist review of A.3 named this as Tension T1: the fallback converts epistemic absence to operational presence without surfacing that conversion to the reviewer. A future version could name the fallback in the session output ("no stage metadata found — presenting all drafts") to make the cut visible.
+
+---
+
+## Decision 5: cmdReview has a different signature from all other cmd\* functions
+
+Every other subcommand handler in `cmd/meshant` has signature `func cmdX(w io.Writer, args []string) error`. `cmdReview` has signature `func cmdReview(w io.Writer, in io.Reader, args []string) error`.
+
+The extra `in io.Reader` parameter exists because `review` is the only interactive subcommand. `RunReviewSession` reads from a reader and writes prompts to a writer. The reader must be injectable so that tests can supply scripted input via `strings.NewReader` rather than requiring a real terminal.
+
+The alternative — using `os.Stdin` directly inside `cmdReview` — would make the function untestable without a real terminal, or would require a more complex mock infrastructure. The extra parameter is a small, visible divergence that makes the testability rationale self-evident.
+
+`run()` calls `cmdReview(w, os.Stdin, args[1:])`. The `run()` signature itself is unchanged (`run(w io.Writer, args []string) error`). The `os.Stdin` reference is confined to one call site. If a second interactive subcommand is added in a later thread, the correct next step is to either add `in io.Reader` to `run()` directly, or introduce a `cmdContext` struct — not to accumulate more signature exceptions.
+
+---
+
+## Decision 6: Interactive prompts go to stderr; data goes to stdout
+
+`RunReviewSession` writes interactive prompts to its `out io.Writer` parameter. In `cmdReview`, this parameter is `os.Stderr`. Accepted/edited draft JSON and the post-session summary go to `w` (stdout or `--output` file).
+
+The separation keeps stdout machine-readable. A reviewer can run `meshant review drafts.json | jq .` and receive clean JSON on stdout while seeing prompts on stderr. Or they can use `--output reviewed.json` to route JSON to a file while the session runs interactively on stdout/stderr.
+
+If prompts went to `w`, stdout would contain a mixture of human-readable prompts and machine-readable JSON, making piping and redirection unreliable. The stderr separation is a standard Unix convention and the right choice for any interactive command that also produces structured output.
+
+This means tests for `cmdReview` cannot capture prompt text without redirecting `os.Stderr`. That is acceptable: the prompt rendering is already tested in the `review` package's own unit tests, where `out` is an injected `bytes.Buffer`.
+
+---
+
+## Decision 7: Provenance/content partition in deriveEdited
+
+`deriveEdited(parent, edited TraceDraft)` splits fields into two sources:
+
+- **Content fields** (from `edited`): `WhatChanged`, `Source`, `Target`, `Mediation`, `Observer`, `Tags`, `UncertaintyNote`, `CriterionRef` — the reviewer's articulation
+- **Provenance fields** (from `parent`): `SourceSpan`, `SourceDocRef`, `IntentionallyBlank` — the extraction provenance, unchanged by the review
+
+`SourceSpan` records where in the source document the trace came from. `SourceDocRef` records the document itself. `IntentionallyBlank` records which content fields were deliberately left empty during extraction. None of these can be changed by the reviewer in the edit flow: the reviewer refines the reading, not the location in the source text.
+
+A reviewer who edits `WhatChanged` is re-articulating what the trace says. A reviewer who changes `SourceSpan` would be claiming the trace came from a different place in the document — a different kind of operation that implies re-extraction, not review. Keeping provenance fields fixed from the parent makes the partition explicit: the review session produces new content readings from fixed source positions.
+
+This tension was named by the ANT-theorist review of A.4 (Tension T1): the provenance/content boundary is itself a cut, and a future use case may want to contest it.
+
+---
+
+## Decision 8: main.go file size debt acknowledged, deferred
+
+`main.go` in `cmd/meshant` reached approximately 1720 lines by the end of Thread A. The project's coding style ceiling is 800 lines per file. The file grew incrementally across milestones (M11 added `cmdDraft`/`cmdPromote`, M12 added `cmdRearticulate`/`cmdLineage`, M13 added `cmdShadow`/`cmdGaps`, B.1 added `cmdBottleneck`, A.5 added `cmdReview`).
+
+No split was made in Thread A. Splitting `main.go` into per-command files (`cmd_review.go`, `cmd_articulate.go`, etc.) would be mechanical — a package-internal reorganisation with no API surface change — but it is a multi-file refactor that was out of scope for A.5's focused change. The architect review of A.5 flagged this explicitly as pre-existing debt, not introduced by A.5.
+
+The refactor is tracked as a separate issue. It should be done before Thread F (if Thread F adds more subcommands) to keep the file navigable.
+
+---
+
+## ANT tensions named during Thread A
+
+### T1: filterReviewable converts epistemic absence to operational presence
+
+`filterReviewable` presents all drafts when no stage metadata exists. This converts the absence of a classification into a decision to include — without naming that conversion to the reviewer. The reviewer cannot tell, from the session, whether they are seeing all drafts because they are all weak-drafts or because no stage metadata was found.
+
+A future version should surface this in the session output: "no stage metadata found — presenting all N drafts." This would name the cut rather than silently performing it.
+
+### T2: Accept and edit share the same ExtractedBy
+
+Accept (relay) and edit (transform) both set `ExtractedBy: "meshant-review"`. The distinction is recoverable by inspecting the chain but is not pre-classified in the data. A downstream analyst who wants to distinguish "the session endorsed" from "the session transformed" must compare draft fields to parent fields.
+
+This is consistent with C1 (avoid premature classification), but it is a named limitation: the `ExtractedBy` field cannot distinguish acceptance from editing without additional analysis.
+
+### T3: Summary denominator names "loaded" count, not "reviewable" count
+
+The post-session summary reports "N accepted/edited out of M loaded." The denominator M is the count of all drafts in the input file, which may include drafts at stages other than `"weak-draft"`. A reviewer who sees only weak-draft records but receives a denominator of all loaded drafts is being given a count that includes elements the session never presented.
+
+This is a C6 concern: the shadow of non-reviewable drafts is not named. The summary performs a god's-eye count (all loaded) while the session operated from a situated position (only reviewable). The non-reviewed drafts are not absent — they are in shadow from the session's position — but the summary does not name that shadow.
+
+A future version could report both counts: "N accepted out of P reviewable (Q total in file)." Naming the reviewable count makes the session's position explicit in its own output.
+
+---
+
+### T4: Skip does not produce a trace — non-action is not recorded as action
+
+When a reviewer skips a draft, no derived record is produced. The draft remains at `"weak-draft"` in the input file. There is no `"rejected"` stage and no skip record.
+
+This is a commitment consistent with C1 (traces before actors): a trace records a moment where something made a difference. A skip is a non-event in the session. Recording it as a `"rejected"` stage would claim that the reviewer performed an analytical act of rejection, when in fact they performed no act at all. Absence is not the same as negative assertion.
+
+The corollary is that the session produces no record of which drafts were presented and skipped. A future session on the same file will present them again. This is intentional — the review session is not a stateful workflow manager. It is a cut, and the next cut may produce different results.
+
+### T5: The review session's own cut is untraced in v1
+
+The review session is a mediating apparatus — it selects, orders, and frames what the reviewer sees (ambiguity warnings, derivation chains, field prompts). It transforms the reviewer's experience of the draft in ways that are not recorded. But the session does not produce a reflexive trace of its own operation.
+
+This is a named instance of C7 (the designer is inside the mesh): the review apparatus shapes what is seen without recording that shaping. The session knows which drafts were presented, which warnings fired, and which fields were shown in the edit flow — but none of this is written to the output. Only the derived drafts are written.
+
+The plan document (`tasks/plan_thread_a.md`) named this shadow explicitly. It is deferred to a later thread, when the framework has enough reflexive infrastructure to record session metadata meaningfully. Naming it here ensures the deferral is visible rather than forgotten.
+
+---
+
+## What Thread A does NOT do
+
+- **Automated promotion** — the review session produces `"reviewed"` stage drafts; it does not automatically call `Promote()`. The reviewer must run `meshant promote` separately.
+- **LLM-assisted review** — the session presents drafts as extracted; it does not fetch context, suggest completions, or call any LLM API. All decisions are made by the human reviewer.
+- **Multi-file sessions** — `meshant review` accepts a single input file. Reviewing multiple files in sequence requires multiple invocations.
+- **Undo/rollback within a session** — once a draft is accepted or edited, the session advances. There is no back-navigation within a session. The original input file is unchanged, so the reviewer can restart with it.
+- **Field clearing** — the edit flow has no mechanism to explicitly clear a field to empty (Enter keeps the current value). Clearing a field is a stronger analytical claim — it should be expressed by adding the field to `IntentionallyBlank` in a separate step.
+- **No `--reviewer` flag** — `ExtractedBy` is always `"meshant-review"`. The session is the cut; the human is part of the apparatus, not a named actor in the provenance field.
+
+---
+
+## Related
+
+- `docs/decisions/tracedraft-v2.md` — TraceDraft schema, ExtractionStage values, provenance fields
+- `docs/decisions/cli-v2.md` — CLI subcommand pattern, outputWriter/confirmOutput helpers
+- `docs/decisions/interpretive-outputs-v1.md` — Thread B decision record (Layer 3 outputs)
+- `tasks/plan_thread_a.md` — detailed design rules, issue-by-issue plan for A.0–A.6
+- `docs/glossary.md` — mediation, cut, shadow, articulation, intermediary vocabulary

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -662,7 +662,7 @@ Parent issue: #86
 - [x] **A.3 (#90) — Session core** — `RunReviewSession`; accept/skip/quit loop; `deriveAccepted` creates new TraceDraft with DerivedFrom link; 47 tests, 98.2% coverage; PR #99 merged
 - [x] **A.4 (#91) — Edit flow** — `runEditFlow`; `deriveEdited`; `parseCommaSeparated`; 8 editable fields, Enter-to-keep, comma-separated slice input; 67 tests, 92.4% coverage; PR #100 merged
 - [x] **A.5 (#92) — CLI wiring** — `cmdReview(w, in, args)` in `cmd/meshant`; `meshant review [--output] <file>`; prompts to stderr, JSON to stdout; 15 tests, 88.2% coverage; PR #101 merged
-- [ ] **A.6 (#93) — Decision record + codemap**
+- [x] **A.6 (#93) — Decision record + codemap** — `docs/decisions/interactive-review-v1.md` (8 decisions, 3 ANT tensions); codemap updated with `cmdReview`, `run()` dispatcher, Key Design Notes
 
 ### Thread C — Multi-Analyst Ingestion Comparison
 


### PR DESCRIPTION
## Summary

- New: \`docs/decisions/interactive-review-v1.md\` — Thread A decision record
- Updated: \`docs/CODEMAPS/meshant.md\` — review package and cmd/meshant sections
- Updated: \`tasks/todo.md\` — A.6 marked complete

## Decision record contents

**8 design decisions:**
1. Render functions return string (articulation/commitment separation)
2. ExtractedBy "meshant-review" for both accept and edit (generalised symmetry, avoids premature classification)
3. Edit is one derivation step (no phantom intermediary)
4. filterReviewable fallback: no stage metadata → present all
5. cmdReview signature divergence (extra \`in io.Reader\` for testability)
6. Prompts to stderr / data to stdout (pipeable clean JSON)
7. Provenance/content partition in deriveEdited
8. main.go size debt acknowledged, deferred

**5 ANT tensions:**
- T1: filterReviewable converts epistemic absence to operational presence (unnamed cut)
- T2: accept and edit share ExtractedBy (distinction recoverable but not pre-classified)
- T3: summary denominator names "loaded" not "reviewable" (C6 — shadow unnamed)
- T4: skip produces no trace — non-action is not recorded as action
- T5: session's own cut is untraced in v1 (C7 named deferral)

## Codemap updates
- \`session.go\` added to review Files table (was missing)
- \`cmdReview\` added to Functions table, \`run()\` dispatcher description, Key Design Notes
- Interactive subcommand and stderr/stdout separation notes added to Key Design Notes
- \`interactive-review-v1.md\` added to Related Decision Records
- \`review\` package Overview description updated

Closes #93