### PR TITLE
C.3: Classification comparison — CompareChainClassifications + chain-diff CLI (#106)

### DIFF
--- a/docs/CODEMAPS/meshant.md
+++ b/docs/CODEMAPS/meshant.md
@@ -1,6 +1,6 @@
 # MeshAnt — Codemap
 
-**Last Updated:** 2026-03-19 (C.2: ExtractionGap — comparing draft sets from two named extraction positions)
+**Last Updated:** 2026-03-19 (C.3: ClassificationDiff — comparing chain classifications from two analyst positions)
 **Module:** `github.com/automatedtomato/mesh-ant/meshant`
 **Go Version:** 1.25
 **Root Directory:** `/meshant`
@@ -58,6 +58,7 @@
 | `draftchain.go` | `FollowDraftChain`, `ClassifyDraftChain`; `DraftStepKind`, `DraftStepClassification` types (M13). |
 | `analyst.go` | `GroupByAnalyst`; analyst-position partitioning for multi-analyst comparison (C.1). |
 | `extractiongap.go` | `CompareExtractions`, `PrintExtractionGap`; `ExtractionGap`, `FieldDisagreement` types (C.2). |
+| `classdiff.go` | `CompareChainClassifications`, `PrintClassificationDiffs`; `ClassificationDiff` type (C.3). Classification-diff analysis: compare how two analyst positions classified the same derivation chain. |
 
 ### Types
 
@@ -70,6 +71,7 @@
 | `DraftStepClassification` | `StepIndex` (int), `Kind` (DraftStepKind), `Reason` (string) | Classification and justification for a single draft chain step (M13). |
 | `ExtractionGap` | `AnalystA` (string), `AnalystB` (string), `OnlyInA` ([]string), `OnlyInB` ([]string), `InBoth` ([]string), `Disagreements` ([]FieldDisagreement) | Comparison of two named extraction positions: partitions drafts by SourceSpan into three visibility groups; records field-level disagreements across 9 content fields (C.2). |
 | `FieldDisagreement` | `SourceSpan` (string), `Field` (string), `ValueA` (string), `ValueB` (string) | Mismatch in a single field for a draft visible from both extraction positions; field name and both values recorded (C.2). |
+| `ClassificationDiff` | `StepIndex` (int), `KindA` (DraftStepKind), `KindB` (DraftStepKind), `ReasonA` (string), `ReasonB` (string) | Classification disagreement at a single step position between two analyst positions; neither value is authoritative (C.3). |
 
 ### Functions
 
@@ -86,6 +88,8 @@
 | `GroupByAnalyst` | `func GroupByAnalyst(drafts []schema.TraceDraft) map[string][]schema.TraceDraft` | Partition drafts by ExtractedBy field (analyst-position cut axis). Preserves encounter order within each group; drafts with empty ExtractedBy grouped under key ""; result map never nil; no aliasing (C.1). |
 | `CompareExtractions` | `func CompareExtractions(analystA string, setA []schema.TraceDraft, analystB string, setB []schema.TraceDraft) ExtractionGap` | Partition two named draft sets by SourceSpan into OnlyInA/OnlyInB/InBoth; compare 9 content fields (WhatChanged, Source, Target, Mediation, Observer, Tags, UncertaintyNote, IntentionallyBlank, SourceDocRef) for drafts visible in both positions; use set-based slice comparison; mark drafts from same SourceSpan but different sets with multiple-drafts sentinel (C.2). |
 | `PrintExtractionGap` | `func PrintExtractionGap(w io.Writer, gap ExtractionGap) error` | Write human-readable extraction gap report to io.Writer. Names both analyst positions, three-way partition with SourceSpan lists, field disagreement block, shadow note (neither position is authoritative), non-authoritative disclaimer (C.2). |
+| `CompareChainClassifications` | `func CompareChainClassifications(chainA, chainB []DraftStepClassification) []ClassificationDiff` | Compare two classified chains by position (0-indexed step index). Returns classifications differing by Kind or Reason, up to min(len(chainA), lenB) steps. Returns non-nil empty slice when chains are identical (C.3). |
+| `PrintClassificationDiffs` | `func PrintClassificationDiffs(w io.Writer, analystA, analystB string, lenA, lenB int, diffs []ClassificationDiff) error` | Write human-readable classification diff report to io.Writer. Names both analyst positions, overall chain length context (lenA/lenB steps), per-diff lines (step position, Kind/Reason for each analyst, position note), footer caveat (neither position is authoritative, data-dependent heuristics) (C.3). |
 
 ## Package: graph
 
@@ -257,7 +261,7 @@ None (persist carries no domain types; wraps graph types).
 
 | File | Contains |
 |------|----------|
-| `main.go` | CLI entry point: subcommand dispatcher, helper types and functions. Includes `cmdDraft`, `cmdPromote` (M11), `cmdRearticulate`, `cmdLineage` (M12), `cmdShadow`, `cmdGaps` (M13), `cmdBottleneck` (B.1), `cmdExtractionGap` (C.2), `cmdReview` (A.5) handlers. (~1800 lines — pre-existing size debt, tracked for future per-command file split.) |
+| `main.go` | CLI entry point: subcommand dispatcher, helper types and functions. Includes `cmdDraft`, `cmdPromote` (M11), `cmdRearticulate`, `cmdLineage` (M12), `cmdShadow`, `cmdGaps` (M13), `cmdBottleneck` (B.1), `cmdExtractionGap` (C.2), `cmdChainDiff` (C.3), `cmdReview` (A.5) handlers. (~2010 lines — pre-existing size debt, tracked for future per-command file split.) |
 | `main_test.go` | Tests: all subcommands, flag parsing, file output, error handling, criterion file loading, draft/promote pipeline (M11). |
 
 ### Types
@@ -289,6 +293,7 @@ None (persist carries no domain types; wraps graph types).
 | `cmdGaps` | `func cmdGaps(w io.Writer, args []string) error` | Subcommand: Load traces, articulate two cuts, compare node sets via `graph.AnalyseGaps()`, print gap report. Optionally appends re-articulation suggestions via `--suggest`. Flags: `--observer-a`, `--observer-b` (required), per-side `--tag-a/b`, `--from-a/b`, `--to-a/b`, `--suggest` (bool), `--output` (M13, B.2). |
 | `cmdBottleneck` | `func cmdBottleneck(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut, identify bottlenecks via `graph.IdentifyBottlenecks()`, print notes via `PrintBottleneckNotes()`. Flags: `--observer` (optional), `--tag`, `--from`, `--to`, `--output` (B.1). |
 | `cmdExtractionGap` | `func cmdExtractionGap(w io.Writer, args []string) error` | Subcommand: Load two TraceDraft JSON files, compare extractions from named positions via `loader.CompareExtractions()`, print gap report via `PrintExtractionGap()`. Flags: `--analyst-a <label>`, `--analyst-b <label>` (both required, names of analyst positions), `--output <file>` (C.2). |
+| `cmdChainDiff` | `func cmdChainDiff(w io.Writer, args []string) error` | Subcommand: Load TraceDraft JSON, build span-scoped derivation chains for two named analyst positions via `loader.FollowDraftChain()` + `loader.ClassifyDraftChain()`, compare classifications via `loader.CompareChainClassifications()`, print diff report via `PrintClassificationDiffs()`. Flags: `--analyst-a <label>`, `--analyst-b <label>` (both required), `--span <source_span>` (required), `--output <file>` (C.3). |
 | `cmdReview` | `func cmdReview(w io.Writer, in io.Reader, args []string) error` | Subcommand: Load TraceDraft JSON, run interactive accept/edit/skip/quit session via `review.RunReviewSession()`. Only interactive subcommand — signature diverges from all other `cmd*` functions by accepting `in io.Reader` for stdin injection (testability). Interactive prompts go to `os.Stderr`; JSON output and summary go to `w`. Flags: `--output <file>` (A.5). |
 | `loadCriterionFile` | `func loadCriterionFile(path string) (graph.EquivalenceCriterion, error)` | Load, decode, and validate an EquivalenceCriterion from a JSON file. Uses `DisallowUnknownFields()` for precision. Zero-value criterion is a hard error. Returns validated criterion or descriptive error. |
 | `outputWriter` | `func outputWriter(w io.Writer, outputPath string) (io.Writer, error)` | Return file writer if `--output` is set, otherwise stdout. |
@@ -436,6 +441,9 @@ cmd/demo/
 | Draft narrative reading of a graph | `graph/narrative.go` → `DraftNarrative()` |
 | Print narrative draft | `graph/narrative.go` → `PrintNarrativeDraft()` |
 | Add narrative draft to articulation output | `cmd/meshant/main.go` → `cmdArticulate()` with `--narrative` flag |
+| Compare chain classifications from two analysts | `loader/classdiff.go` → `CompareChainClassifications()` |
+| Print classification diff report | `loader/classdiff.go` → `PrintClassificationDiffs()` |
+| Classification diff via CLI | `cmd/meshant/main.go` → `cmdChainDiff()` |
 | Read critique prompt contract | `data/prompts/critique_pass.md` |
 | Run minimal demo | `cmd/demo/main.go` → `run()` |
 

--- a/meshant/cmd/meshant/main.go
+++ b/meshant/cmd/meshant/main.go
@@ -13,6 +13,7 @@
 //   - bottleneck:      identify provisionally central elements from an articulation (B.1)
 //   - review:          interactively accept/edit/skip weak-draft records (A.5)
 //   - extraction-gap:  compare extraction positions across a shared draft set (C.2)
+//   - chain-diff:      compare derivation-chain classifications across two analyst positions (C.3)
 //
 // The testable logic lives in run() and each cmd* function. main() itself is
 // a thin wrapper that wires os.Stdout and os.Args, then exits non-zero on
@@ -219,6 +220,8 @@ func run(w io.Writer, args []string) error {
 		return cmdBottleneck(w, args[1:])
 	case "extraction-gap":
 		return cmdExtractionGap(w, args[1:])
+	case "chain-diff":
+		return cmdChainDiff(w, args[1:])
 	case "review":
 		// cmdReview receives os.Stdin so the interactive prompts can read from
 		// the terminal. The extra in parameter keeps the session testable
@@ -251,6 +254,7 @@ Commands:
   bottleneck      identify provisionally central elements from an articulation (flags: --observer, --tag, --from, --to, --output)
   review          interactively accept/edit/skip weak-draft records (flags: --output)
   extraction-gap  compare extraction positions across a shared draft set (flags: --analyst-a, --analyst-b, --output)
+  chain-diff      compare derivation-chain classifications across two analyst positions (flags: --analyst-a, --analyst-b, --span, --output)
 
 Run 'meshant <command> --help' for command-specific flags.`
 }
@@ -1818,6 +1822,180 @@ func cmdExtractionGap(w io.Writer, args []string) error {
 	}
 
 	if err := loader.PrintExtractionGap(dest, gap); err != nil {
+		return err
+	}
+
+	return confirmOutput(w, outputPath)
+}
+
+// cmdChainDiff implements the "chain-diff" subcommand.
+//
+// It loads a drafts JSON file, groups drafts by analyst (ExtractedBy), builds
+// a derivation chain for each analyst position for the requested SourceSpan,
+// classifies each chain with ClassifyDraftChain, and compares the resulting
+// classifications with CompareChainClassifications.
+//
+// The comparison surfaces steps where the two positions assigned different
+// DraftStepKind values. Length asymmetry is reported when the chains have
+// different numbers of steps — steps beyond the shorter chain are not visible.
+//
+// Required flags:
+//   - --analyst-a: label for the first analyst position
+//   - --analyst-b: label for the second analyst position
+//   - --span: SourceSpan to compare classification chains for
+//
+// Optional flags:
+//   - --output: write report to file instead of stdout
+//
+// Required positional argument: path to a drafts JSON file.
+//
+// Note: the span string is treated as a shared key to align the two analyst
+// positions. Identical span strings do not guarantee that both positions
+// worked from identical source material — the comparison assumes they did.
+//
+// Returns an error if required flags are missing, the file cannot be loaded,
+// either analyst label is not found, or the span is absent from one position.
+func cmdChainDiff(w io.Writer, args []string) error {
+	fs := flag.NewFlagSet("chain-diff", flag.ContinueOnError)
+
+	var analystA, analystB, span, outputPath string
+	fs.StringVar(&analystA, "analyst-a", "", "label for analyst position A (required)")
+	fs.StringVar(&analystB, "analyst-b", "", "label for analyst position B (required)")
+	fs.StringVar(&span, "span", "", "source span to compare classification chains for (required)")
+	fs.StringVar(&outputPath, "output", "", "write output to file (e.g. diff.txt)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Validate required flags.
+	if analystA == "" {
+		return fmt.Errorf("chain-diff: --analyst-a is required")
+	}
+	if analystB == "" {
+		return fmt.Errorf("chain-diff: --analyst-b is required")
+	}
+	if analystA == analystB {
+		return fmt.Errorf("chain-diff: --analyst-a and --analyst-b must be different labels (got %q for both)", analystA)
+	}
+	if span == "" {
+		return fmt.Errorf("chain-diff: --span is required")
+	}
+
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return fmt.Errorf("chain-diff: path to drafts.json required\n\nUsage: meshant chain-diff --analyst-a <label> --analyst-b <label> --span <source_span> [--output file] <drafts.json>")
+	}
+	path := remaining[0]
+
+	// Load and validate all draft records.
+	drafts, err := loader.LoadDrafts(path)
+	if err != nil {
+		return fmt.Errorf("chain-diff: %w", err)
+	}
+
+	// Partition drafts by analyst position (ExtractedBy field).
+	byAnalyst := loader.GroupByAnalyst(drafts)
+
+	// Look up each analyst label; report all available labels on failure.
+	lookupAnalyst := func(label string) ([]schema.TraceDraft, error) {
+		set, ok := byAnalyst[label]
+		if !ok {
+			available := make([]string, 0, len(byAnalyst))
+			for k := range byAnalyst {
+				available = append(available, k)
+			}
+			sort.Strings(available)
+			return nil, fmt.Errorf("chain-diff: analyst %q not found; available: %s",
+				label, strings.Join(available, ", "))
+		}
+		return set, nil
+	}
+
+	setA, err := lookupAnalyst(analystA)
+	if err != nil {
+		return err
+	}
+	setB, err := lookupAnalyst(analystB)
+	if err != nil {
+		return err
+	}
+
+	// buildChain finds the root draft for the given span in analystDrafts,
+	// follows the derivation chain, and returns the classification of each step.
+	// The root is the span draft whose DerivedFrom is absent from this span's
+	// draft IDs — that is, the analyst's earliest draft for this span.
+	//
+	// Scope note: root-finding uses the span-scoped ID set (spanIDs), not the
+	// full analyst set. This prevents a cross-span DerivedFrom link from being
+	// mistaken for an in-span parent, which would cause the root to be placed
+	// at a mid-chain node. FollowDraftChain similarly receives only spanDrafts
+	// so the traversal cannot follow links outside this span.
+	buildChain := func(analystLabel string, analystDrafts []schema.TraceDraft) ([]loader.DraftStepClassification, error) {
+		// Filter to drafts for the requested span.
+		var spanDrafts []schema.TraceDraft
+		for _, d := range analystDrafts {
+			if d.SourceSpan == span {
+				spanDrafts = append(spanDrafts, d)
+			}
+		}
+		if len(spanDrafts) == 0 {
+			return nil, fmt.Errorf("chain-diff: span %q not found for analyst %q", span, analystLabel)
+		}
+
+		// Build a span-scoped ID set. Root candidates are span drafts whose
+		// DerivedFrom is absent from this set — their parent (if any) is outside
+		// the span, making them the starting point of this analyst's chain.
+		spanIDs := make(map[string]bool, len(spanDrafts))
+		for _, d := range spanDrafts {
+			spanIDs[d.ID] = true
+		}
+
+		var roots []string
+		for _, d := range spanDrafts {
+			if d.DerivedFrom == "" || !spanIDs[d.DerivedFrom] {
+				roots = append(roots, d.ID)
+			}
+		}
+		if len(roots) == 0 {
+			// Every span draft has a parent within the span — possible cycle.
+			return nil, fmt.Errorf("chain-diff: no chain root found for span %q under analyst %q (possible cycle in derivation links)", span, analystLabel)
+		}
+		if len(roots) > 1 {
+			// Multiple independent roots mean the chain is ambiguous — refuse
+			// to pick one silently, as the comparison would vary by JSON order.
+			return nil, fmt.Errorf("chain-diff: ambiguous chain root for span %q under analyst %q: multiple root candidates %v", span, analystLabel, roots)
+		}
+		rootID := roots[0]
+
+		// Follow the derivation chain from the root within the span-scoped set.
+		// Passing spanDrafts (not analystDrafts) ensures the traversal cannot
+		// cross into a draft that belongs to a different SourceSpan.
+		chain := loader.FollowDraftChain(spanDrafts, rootID)
+		return loader.ClassifyDraftChain(chain), nil
+	}
+
+	chainA, err := buildChain(analystA, setA)
+	if err != nil {
+		return err
+	}
+	chainB, err := buildChain(analystB, setB)
+	if err != nil {
+		return err
+	}
+
+	// Compare the two classification chains and render the report.
+	diffs := loader.CompareChainClassifications(chainA, chainB)
+
+	dest, err := outputWriter(w, outputPath)
+	if err != nil {
+		return fmt.Errorf("chain-diff: %w", err)
+	}
+	if f, ok := dest.(*os.File); ok {
+		defer f.Close()
+	}
+
+	if err := loader.PrintClassificationDiffs(dest, analystA, analystB, len(chainA), len(chainB), diffs); err != nil {
 		return err
 	}
 

--- a/meshant/cmd/meshant/main_test.go
+++ b/meshant/cmd/meshant/main_test.go
@@ -3219,3 +3219,345 @@ func TestCmdExtractionGap_OutputToFile(t *testing.T) {
 		t.Errorf("stdout missing file path confirmation; got: %s", buf.String())
 	}
 }
+
+// --- chain-diff integration tests ---
+
+// chainDiffDraftsJSON encodes two analyst positions over the same source span
+// ("span-chain"), each with a two-draft derivation chain.
+//
+// analyst-a: a-root → a-rev1: what_changed changes, extraction_stage unchanged
+//            → ClassifyDraftChain classifies step 1 as DraftMediator.
+//
+// analyst-b: b-root → b-rev1: what_changed changes AND extraction_stage advances
+//            → ClassifyDraftChain classifies step 1 as DraftTranslation.
+//
+// The two chains therefore diverge at step 1 (mediator vs translation).
+const chainDiffDraftsJSON = `[
+  {"id":"a-root","source_span":"span-chain","extracted_by":"analyst-a","what_changed":"initial A","extraction_stage":"weak-draft"},
+  {"id":"a-rev1","source_span":"span-chain","extracted_by":"analyst-a","derived_from":"a-root","what_changed":"revised A","extraction_stage":"weak-draft"},
+  {"id":"b-root","source_span":"span-chain","extracted_by":"analyst-b","what_changed":"initial B","extraction_stage":"weak-draft"},
+  {"id":"b-rev1","source_span":"span-chain","extracted_by":"analyst-b","derived_from":"b-root","what_changed":"revised B","extraction_stage":"reviewed"}
+]`
+
+// chainDiffIdenticalJSON encodes two analyst positions where both chains
+// produce an identical classification (both are DraftMediator at step 1).
+const chainDiffIdenticalJSON = `[
+  {"id":"a-root","source_span":"span-same","extracted_by":"analyst-a","what_changed":"initial","extraction_stage":"weak-draft"},
+  {"id":"a-rev1","source_span":"span-same","extracted_by":"analyst-a","derived_from":"a-root","what_changed":"revised","extraction_stage":"weak-draft"},
+  {"id":"b-root","source_span":"span-same","extracted_by":"analyst-b","what_changed":"initial","extraction_stage":"weak-draft"},
+  {"id":"b-rev1","source_span":"span-same","extracted_by":"analyst-b","derived_from":"b-root","what_changed":"revised","extraction_stage":"weak-draft"}
+]`
+
+// TestCmdChainDiff_BasicRun verifies that cmdChainDiff produces a classification
+// diff report for two analysts with diverging chain classifications. The
+// fixture's structure is known: step 1 diverges (mediator vs translation).
+func TestCmdChainDiff_BasicRun(t *testing.T) {
+	path := writeTempJSONForDraft(t, chainDiffDraftsJSON)
+
+	var buf bytes.Buffer
+	err := cmdChainDiff(&buf, []string{
+		"--analyst-a", "analyst-a",
+		"--analyst-b", "analyst-b",
+		"--span", "span-chain",
+		path,
+	})
+	if err != nil {
+		t.Fatalf("cmdChainDiff(): unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	// Output must contain both analyst labels, the span name, the step index,
+	// and both classification kinds — these are the minimum meaningful assertions.
+	for _, want := range []string{
+		"analyst-a", "analyst-b",
+		"Step 1",
+		"mediator",
+		"translation",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("cmdChainDiff(): output missing %q;\noutput:\n%s", want, out)
+		}
+	}
+}
+
+// TestCmdChainDiff_IdenticalChains verifies that when both analyst chains
+// produce the same classification at every step, the output contains a
+// "No classification divergence" message.
+func TestCmdChainDiff_IdenticalChains(t *testing.T) {
+	path := writeTempJSONForDraft(t, chainDiffIdenticalJSON)
+
+	var buf bytes.Buffer
+	err := cmdChainDiff(&buf, []string{
+		"--analyst-a", "analyst-a",
+		"--analyst-b", "analyst-b",
+		"--span", "span-same",
+		path,
+	})
+	if err != nil {
+		t.Fatalf("cmdChainDiff(): unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "No classification divergence") {
+		t.Errorf("cmdChainDiff(): expected 'No classification divergence' message;\noutput:\n%s", out)
+	}
+}
+
+// TestCmdChainDiff_MissingFlags verifies that omitting required flags or
+// the positional argument returns an error. Table-driven: covers each missing
+// required input including the same-label guard.
+func TestCmdChainDiff_MissingFlags(t *testing.T) {
+	path := writeTempJSONForDraft(t, chainDiffDraftsJSON)
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "missing --analyst-a",
+			args: []string{"--analyst-b", "analyst-b", "--span", "span-chain", path},
+		},
+		{
+			name: "missing --analyst-b",
+			args: []string{"--analyst-a", "analyst-a", "--span", "span-chain", path},
+		},
+		{
+			name: "missing --span",
+			args: []string{"--analyst-a", "analyst-a", "--analyst-b", "analyst-b", path},
+		},
+		{
+			name: "missing positional arg",
+			args: []string{"--analyst-a", "analyst-a", "--analyst-b", "analyst-b", "--span", "span-chain"},
+		},
+		{
+			name: "same label for both",
+			args: []string{"--analyst-a", "analyst-a", "--analyst-b", "analyst-a", "--span", "span-chain", path},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := cmdChainDiff(&buf, tc.args)
+			if err == nil {
+				t.Fatalf("cmdChainDiff(%v): want error, got nil", tc.args)
+			}
+		})
+	}
+}
+
+// TestCmdChainDiff_MissingAnalystLabel verifies that requesting a label not
+// present in the drafts produces an error containing "not found", for both
+// the --analyst-a and --analyst-b paths.
+func TestCmdChainDiff_MissingAnalystLabel(t *testing.T) {
+	path := writeTempJSONForDraft(t, chainDiffDraftsJSON)
+
+	cases := []struct {
+		name     string
+		analystA string
+		analystB string
+	}{
+		{
+			name:     "analystA not found",
+			analystA: "nonexistent-label",
+			analystB: "analyst-b",
+		},
+		{
+			name:     "analystB not found",
+			analystA: "analyst-a",
+			analystB: "nonexistent-label",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := cmdChainDiff(&buf, []string{
+				"--analyst-a", tc.analystA,
+				"--analyst-b", tc.analystB,
+				"--span", "span-chain",
+				path,
+			})
+			if err == nil {
+				t.Fatal("cmdChainDiff(): want error for missing analyst label, got nil")
+			}
+			if !strings.Contains(err.Error(), "not found") {
+				t.Errorf("cmdChainDiff(): error should contain 'not found'; got: %v", err)
+			}
+		})
+	}
+}
+
+// TestCmdChainDiff_SpanNotFound verifies that requesting a span not present
+// for a given analyst produces an error containing "not found". Table-driven
+// to cover both the analyst-a path (first buildChain call) and the analyst-b
+// path (second buildChain call, only reached when analyst-a finds the span).
+func TestCmdChainDiff_SpanNotFound(t *testing.T) {
+	// asymmetricJSON: analyst-a has span-chain; analyst-b does not.
+	// Used to test the analyst-b-span-missing path independently.
+	const asymmetricJSON = `[
+	  {"id":"a-root","source_span":"span-chain","extracted_by":"analyst-a","what_changed":"initial"},
+	  {"id":"b-root","source_span":"other-span","extracted_by":"analyst-b","what_changed":"initial"}
+	]`
+
+	cases := []struct {
+		name     string
+		fixture  string
+		analystA string
+		analystB string
+		span     string
+	}{
+		{
+			name:     "span missing for analyst-a",
+			fixture:  chainDiffDraftsJSON,
+			analystA: "analyst-a",
+			analystB: "analyst-b",
+			span:     "nonexistent-span",
+		},
+		{
+			name:     "span missing for analyst-b",
+			fixture:  asymmetricJSON,
+			analystA: "analyst-a",
+			analystB: "analyst-b",
+			span:     "span-chain",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempJSONForDraft(t, tc.fixture)
+			var buf bytes.Buffer
+			err := cmdChainDiff(&buf, []string{
+				"--analyst-a", tc.analystA,
+				"--analyst-b", tc.analystB,
+				"--span", tc.span,
+				path,
+			})
+			if err == nil {
+				t.Fatal("cmdChainDiff(): want error for missing span, got nil")
+			}
+			if !strings.Contains(err.Error(), "not found") {
+				t.Errorf("cmdChainDiff(): error should contain 'not found'; got: %v", err)
+			}
+		})
+	}
+}
+
+// TestCmdChainDiff_OutputToFile verifies that --output writes the report to
+// a file rather than stdout, and prints a confirmation to stdout.
+func TestCmdChainDiff_OutputToFile(t *testing.T) {
+	path := writeTempJSONForDraft(t, chainDiffDraftsJSON)
+	outFile := filepath.Join(t.TempDir(), "diff.txt")
+
+	var buf bytes.Buffer
+	err := cmdChainDiff(&buf, []string{
+		"--analyst-a", "analyst-a",
+		"--analyst-b", "analyst-b",
+		"--span", "span-chain",
+		"--output", outFile,
+		path,
+	})
+	if err != nil {
+		t.Fatalf("cmdChainDiff(): unexpected error: %v", err)
+	}
+
+	// File must exist and contain the analyst labels and the known divergence.
+	content, readErr := os.ReadFile(outFile)
+	if readErr != nil {
+		t.Fatalf("output file not created: %v", readErr)
+	}
+	for _, want := range []string{"analyst-a", "analyst-b", "Step 1", "mediator", "translation"} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("output file missing %q", want)
+		}
+	}
+	// Stdout should contain the confirmation message including the file path.
+	if !strings.Contains(buf.String(), outFile) {
+		t.Errorf("stdout missing file path confirmation; got: %s", buf.String())
+	}
+}
+
+// TestCmdChainDiff_BadPath verifies that a nonexistent file path returns a
+// load error, consistent with TestCmdExtractionGap_BadPath.
+func TestCmdChainDiff_BadPath(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdChainDiff(&buf, []string{
+		"--analyst-a", "analyst-a",
+		"--analyst-b", "analyst-b",
+		"--span", "span-chain",
+		"/nonexistent/path/drafts.json",
+	})
+	if err == nil {
+		t.Fatal("cmdChainDiff(): want error for bad path, got nil")
+	}
+}
+
+// TestCmdChainDiff_MalformedJSON verifies that malformed JSON input returns a
+// parse error, consistent with TestCmdExtractionGap_MalformedJSON.
+func TestCmdChainDiff_MalformedJSON(t *testing.T) {
+	path := writeTempJSONForDraft(t, `[{"source_span": "incomplete"`)
+
+	var buf bytes.Buffer
+	err := cmdChainDiff(&buf, []string{
+		"--analyst-a", "analyst-a",
+		"--analyst-b", "analyst-b",
+		"--span", "span-chain",
+		path,
+	})
+	if err == nil {
+		t.Fatal("cmdChainDiff(): want error for malformed JSON, got nil")
+	}
+}
+
+// TestCmdChainDiff_AmbiguousRoot verifies that when an analyst has two
+// independent root candidates for a span (two drafts with no in-span parent),
+// buildChain returns an error rather than silently picking one by encounter order.
+func TestCmdChainDiff_AmbiguousRoot(t *testing.T) {
+	// Both analyst-a drafts for "span-chain" have no DerivedFrom — two roots.
+	const ambiguousRootJSON = `[
+	  {"id":"a-root1","source_span":"span-chain","extracted_by":"analyst-a","what_changed":"version one"},
+	  {"id":"a-root2","source_span":"span-chain","extracted_by":"analyst-a","what_changed":"version two"},
+	  {"id":"b-root","source_span":"span-chain","extracted_by":"analyst-b","what_changed":"initial B"},
+	  {"id":"b-rev1","source_span":"span-chain","extracted_by":"analyst-b","derived_from":"b-root","what_changed":"revised B","extraction_stage":"reviewed"}
+	]`
+	path := writeTempJSONForDraft(t, ambiguousRootJSON)
+
+	var buf bytes.Buffer
+	err := cmdChainDiff(&buf, []string{
+		"--analyst-a", "analyst-a",
+		"--analyst-b", "analyst-b",
+		"--span", "span-chain",
+		path,
+	})
+	if err == nil {
+		t.Fatal("cmdChainDiff(): want error for ambiguous root, got nil")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") && !strings.Contains(err.Error(), "multiple") {
+		t.Errorf("cmdChainDiff(): error should mention ambiguity; got: %v", err)
+	}
+}
+
+// TestCmdChainDiff_CyclicDerivation verifies that when an analyst's span drafts
+// form a cycle (every draft references another as its parent — no root exists),
+// buildChain returns an error rather than looping or returning incorrect output.
+func TestCmdChainDiff_CyclicDerivation(t *testing.T) {
+	// analyst-a: a-draft1.DerivedFrom = a-draft2, a-draft2.DerivedFrom = a-draft1 — cycle.
+	// Neither draft qualifies as a root (each has an in-span parent).
+	const cyclicJSON = `[
+	  {"id":"a-draft1","source_span":"span-chain","extracted_by":"analyst-a","derived_from":"a-draft2","what_changed":"v1"},
+	  {"id":"a-draft2","source_span":"span-chain","extracted_by":"analyst-a","derived_from":"a-draft1","what_changed":"v2"},
+	  {"id":"b-root","source_span":"span-chain","extracted_by":"analyst-b","what_changed":"initial B"},
+	  {"id":"b-rev1","source_span":"span-chain","extracted_by":"analyst-b","derived_from":"b-root","what_changed":"revised B"}
+	]`
+	path := writeTempJSONForDraft(t, cyclicJSON)
+
+	var buf bytes.Buffer
+	err := cmdChainDiff(&buf, []string{
+		"--analyst-a", "analyst-a",
+		"--analyst-b", "analyst-b",
+		"--span", "span-chain",
+		path,
+	})
+	if err == nil {
+		t.Fatal("cmdChainDiff(): want error for cyclic derivation, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") && !strings.Contains(err.Error(), "no chain root") {
+		t.Errorf("cmdChainDiff(): error should mention cycle or no-root; got: %v", err)
+	}
+}

--- a/meshant/loader/classdiff.go
+++ b/meshant/loader/classdiff.go
@@ -1,0 +1,166 @@
+// classdiff.go provides classification-diff analysis — comparing how two analyst
+// positions classified the same derivation chain, without treating either
+// position as authoritative.
+//
+// CompareChainClassifications takes two slices of DraftStepClassification (one
+// per analyst position) and produces a []ClassificationDiff: one entry for each
+// step where the two positions assigned a different Kind.
+//
+// PrintClassificationDiffs renders that diff to any io.Writer in a human-readable
+// format that names both positions using "Position A / Position B" framing and
+// notes any length asymmetry between the two chains.
+//
+// Neither position is treated as primary. The divergence is the data — not a verdict.
+package loader
+
+import (
+	"fmt"
+	"io"
+)
+
+// ClassificationDiff records that two analyst positions classified the same
+// derivation step differently. Neither classification is authoritative.
+//
+// StepIndex matches DraftStepClassification.StepIndex (1-based).
+type ClassificationDiff struct {
+	// StepIndex is the derivation step where the two positions diverge.
+	// 1-based: StepIndex 1 = the step from chain[0] to chain[1].
+	StepIndex int
+
+	// KindA is analyst A's classification for this step.
+	KindA DraftStepKind
+
+	// KindB is analyst B's classification for this step.
+	KindB DraftStepKind
+
+	// ReasonA is analyst A's justification. Carried forward from the
+	// DraftStepClassification so the caller can inspect the divergence.
+	ReasonA string
+
+	// ReasonB is analyst B's justification.
+	ReasonB string
+}
+
+// CompareChainClassifications compares two classification slices step by step
+// and returns diffs for steps where Kind differs. Comparison is by position
+// (same slice index = same derivation depth), up to min(len(chainA), len(chainB)).
+// Steps beyond the shorter chain are not compared — length difference is surfaced
+// by the caller (e.g., PrintClassificationDiffs). Returns non-nil empty slice
+// when both chains are empty or all steps agree.
+func CompareChainClassifications(chainA, chainB []DraftStepClassification) []ClassificationDiff {
+	// Return non-nil empty slice so callers can range without nil checks.
+	result := []ClassificationDiff{}
+
+	// Compare only up to the length of the shorter chain.
+	limit := len(chainA)
+	if len(chainB) < limit {
+		limit = len(chainB)
+	}
+
+	for i := 0; i < limit; i++ {
+		a := chainA[i]
+		b := chainB[i]
+
+		// Emit a diff only when the Kinds diverge. Reason differences alone
+		// are not diffs — they represent different justifications for the same
+		// classification judgment, which is analytically distinct from
+		// disagreeing on the classification itself.
+		//
+		// StepIndex is derived from the loop counter (i+1, 1-based) rather than
+		// a.StepIndex or b.StepIndex. Using the loop position makes the index
+		// unambiguous: it is the positional comparison depth, not the raw field
+		// value from either input chain. This matters if a caller passes chains
+		// with non-sequential or misaligned StepIndex values — the comparison
+		// remains correct and the reported index is always interpretable.
+		if a.Kind != b.Kind {
+			result = append(result, ClassificationDiff{
+				StepIndex: i + 1,
+				KindA:     a.Kind,
+				KindB:     b.Kind,
+				ReasonA:   a.Reason,
+				ReasonB:   b.Reason,
+			})
+		}
+	}
+
+	return result
+}
+
+// PrintClassificationDiffs writes a classification-diff report to w.
+//
+// analystA, analystB: the position labels (e.g., "alice", "bob").
+// lenA, lenB: the total step counts of each chain, used to note any length
+// asymmetry — steps beyond the shorter chain were not visible in the comparison.
+// diffs: the divergences from CompareChainClassifications.
+//
+// Uses "Position A (analystA) / Position B (analystB)" framing throughout.
+// Neither position is treated as authoritative. Closing note: "Neither
+// classification is authoritative. Each reflects where it stands."
+//
+// Returns the first write error encountered, if any, wrapped with
+// "loader: PrintClassificationDiffs: %w".
+func PrintClassificationDiffs(w io.Writer, analystA, analystB string, lenA, lenB int, diffs []ClassificationDiff) error {
+	lines := []string{
+		"=== Classification Diff ===",
+		"",
+		fmt.Sprintf("Position A: %s", analystA),
+		fmt.Sprintf("Position B: %s", analystB),
+	}
+
+	// Note length asymmetry when the two chains have different numbers of steps.
+	// Steps beyond the shorter chain were not visible in this comparison.
+	if lenA != lenB {
+		shorter := lenA
+		if lenB < shorter {
+			shorter = lenB
+		}
+		lines = append(lines,
+			"",
+			fmt.Sprintf("Position A has %d steps; Position B has %d steps. Steps beyond position %d are not visible in this comparison.",
+				lenA, lenB, shorter),
+		)
+	}
+
+	lines = append(lines,
+		"",
+		fmt.Sprintf("Divergences: %d", len(diffs)),
+	)
+
+	if len(diffs) == 0 {
+		// No divergence: both positions independently produced the same reading for
+		// each comparable step — not consensus, but convergence from separate positions.
+		lines = append(lines, "", "No classification divergence — both positions produced the same reading for every comparable step.")
+	} else {
+		// List each divergence: step index, Kind from each position, and the
+		// justification each position offered.
+		lines = append(lines, "")
+		for _, d := range diffs {
+			lines = append(lines,
+				fmt.Sprintf("Step %d:", d.StepIndex),
+				fmt.Sprintf("  Position A (%s): %s", analystA, d.KindA),
+				fmt.Sprintf("    Reason: %s", d.ReasonA),
+				fmt.Sprintf("  Position B (%s): %s", analystB, d.KindB),
+				fmt.Sprintf("    Reason: %s", d.ReasonB),
+			)
+		}
+	}
+
+	// Closing note: no position holds the authoritative reading.
+	// Step indices reflect positional depth in each chain, not a shared
+	// identity across positions — two analysts may classify "step 2" without
+	// having produced the same derivation moment.
+	lines = append(lines,
+		"",
+		"---",
+		"Neither classification is authoritative. Each reflects where it stands.",
+		"Step indices reflect positional depth in each chain, not shared derivation identity.",
+	)
+
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("loader: PrintClassificationDiffs: %w", err)
+		}
+	}
+	return nil
+}
+

--- a/meshant/loader/classdiff_test.go
+++ b/meshant/loader/classdiff_test.go
@@ -1,0 +1,359 @@
+// classdiff_test.go tests CompareChainClassifications and PrintClassificationDiffs —
+// the classification-diff analysis functions for the loader package.
+//
+// These tests use the black-box package loader_test to verify observable
+// behaviour only: diff detection by position, length-mismatch handling, and
+// print output content. Implementation internals are not tested.
+//
+// Test groups:
+//  1. CompareChainClassifications — core diff logic
+//  2. PrintClassificationDiffs — report rendering
+package loader_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/loader"
+)
+
+// makeClassif constructs a DraftStepClassification with the given fields.
+// Used as a concise builder in table-style test cases.
+func makeClassif(stepIndex int, kind loader.DraftStepKind, reason string) loader.DraftStepClassification {
+	return loader.DraftStepClassification{StepIndex: stepIndex, Kind: kind, Reason: reason}
+}
+
+// --- Group 1: CompareChainClassifications ---
+
+// TestCompareChainClassifications_EmptyBoth verifies that when both chains are
+// nil, the result is non-nil and has zero diffs.
+func TestCompareChainClassifications_EmptyBoth(t *testing.T) {
+	diffs := loader.CompareChainClassifications(nil, nil)
+
+	if diffs == nil {
+		t.Error("CompareChainClassifications(nil, nil): want non-nil empty slice, got nil")
+	}
+	if len(diffs) != 0 {
+		t.Errorf("CompareChainClassifications(nil, nil): want 0 diffs, got %d: %v", len(diffs), diffs)
+	}
+}
+
+// TestCompareChainClassifications_EmptyOneChain verifies that when one chain is
+// nil and the other is non-nil, the result is non-nil with zero diffs (no steps
+// can be compared because min(0, n) = 0).
+func TestCompareChainClassifications_EmptyOneChain(t *testing.T) {
+	chainB := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "no change"),
+	}
+
+	// chainA nil, chainB non-nil.
+	diffsA := loader.CompareChainClassifications(nil, chainB)
+	if diffsA == nil {
+		t.Error("CompareChainClassifications(nil, nonNil): want non-nil empty slice, got nil")
+	}
+	if len(diffsA) != 0 {
+		t.Errorf("CompareChainClassifications(nil, nonNil): want 0 diffs, got %d", len(diffsA))
+	}
+
+	// chainA non-nil, chainB nil.
+	chainA := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftMediator, "content changed"),
+	}
+	diffsB := loader.CompareChainClassifications(chainA, nil)
+	if diffsB == nil {
+		t.Error("CompareChainClassifications(nonNil, nil): want non-nil empty slice, got nil")
+	}
+	if len(diffsB) != 0 {
+		t.Errorf("CompareChainClassifications(nonNil, nil): want 0 diffs, got %d", len(diffsB))
+	}
+}
+
+// TestCompareChainClassifications_IdenticalChains verifies that when both chains
+// classify every step the same way, zero diffs are returned.
+func TestCompareChainClassifications_IdenticalChains(t *testing.T) {
+	chainA := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-a-1"),
+		makeClassif(2, loader.DraftMediator, "reason-a-2"),
+		makeClassif(3, loader.DraftTranslation, "reason-a-3"),
+	}
+	// chainB uses different reasons but the same Kinds — Reason doesn't drive a diff.
+	chainB := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-b-1"),
+		makeClassif(2, loader.DraftMediator, "reason-b-2"),
+		makeClassif(3, loader.DraftTranslation, "reason-b-3"),
+	}
+
+	diffs := loader.CompareChainClassifications(chainA, chainB)
+
+	if diffs == nil {
+		t.Error("identical chains: want non-nil empty slice, got nil")
+	}
+	if len(diffs) != 0 {
+		t.Errorf("identical chains: want 0 diffs, got %d: %v", len(diffs), diffs)
+	}
+}
+
+// TestCompareChainClassifications_SingleDivergence verifies that when two chains
+// agree on step 1 but diverge on step 2, exactly one diff is returned with the
+// correct StepIndex, KindA, KindB, ReasonA, and ReasonB.
+func TestCompareChainClassifications_SingleDivergence(t *testing.T) {
+	chainA := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-a-step1"),
+		makeClassif(2, loader.DraftMediator, "reason-a-step2"),
+	}
+	chainB := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-b-step1"), // same Kind as A
+		makeClassif(2, loader.DraftTranslation, "reason-b-step2"), // different Kind
+	}
+
+	diffs := loader.CompareChainClassifications(chainA, chainB)
+
+	if len(diffs) != 1 {
+		t.Fatalf("single divergence: want 1 diff, got %d: %v", len(diffs), diffs)
+	}
+
+	d := diffs[0]
+	if d.StepIndex != 2 {
+		t.Errorf("diff.StepIndex: want 2, got %d", d.StepIndex)
+	}
+	if d.KindA != loader.DraftMediator {
+		t.Errorf("diff.KindA: want %q, got %q", loader.DraftMediator, d.KindA)
+	}
+	if d.KindB != loader.DraftTranslation {
+		t.Errorf("diff.KindB: want %q, got %q", loader.DraftTranslation, d.KindB)
+	}
+	if d.ReasonA != "reason-a-step2" {
+		t.Errorf("diff.ReasonA: want %q, got %q", "reason-a-step2", d.ReasonA)
+	}
+	if d.ReasonB != "reason-b-step2" {
+		t.Errorf("diff.ReasonB: want %q, got %q", "reason-b-step2", d.ReasonB)
+	}
+}
+
+// TestCompareChainClassifications_FullDivergence verifies that when every step
+// has a different Kind, the number of diffs equals len(chain).
+func TestCompareChainClassifications_FullDivergence(t *testing.T) {
+	chainA := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-a-1"),
+		makeClassif(2, loader.DraftMediator, "reason-a-2"),
+		makeClassif(3, loader.DraftTranslation, "reason-a-3"),
+	}
+	chainB := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftTranslation, "reason-b-1"),  // differs
+		makeClassif(2, loader.DraftIntermediary, "reason-b-2"), // differs
+		makeClassif(3, loader.DraftMediator, "reason-b-3"),     // differs
+	}
+
+	diffs := loader.CompareChainClassifications(chainA, chainB)
+
+	if len(diffs) != 3 {
+		t.Fatalf("full divergence: want 3 diffs, got %d: %v", len(diffs), diffs)
+	}
+
+	// Each diff must carry the correct StepIndex, KindA, and KindB.
+	wantStep := []int{1, 2, 3}
+	wantKindA := []loader.DraftStepKind{loader.DraftIntermediary, loader.DraftMediator, loader.DraftTranslation}
+	wantKindB := []loader.DraftStepKind{loader.DraftTranslation, loader.DraftIntermediary, loader.DraftMediator}
+	for i, d := range diffs {
+		if d.StepIndex != wantStep[i] {
+			t.Errorf("diffs[%d].StepIndex: want %d, got %d", i, wantStep[i], d.StepIndex)
+		}
+		if d.KindA != wantKindA[i] {
+			t.Errorf("diffs[%d].KindA: want %q, got %q", i, wantKindA[i], d.KindA)
+		}
+		if d.KindB != wantKindB[i] {
+			t.Errorf("diffs[%d].KindB: want %q, got %q", i, wantKindB[i], d.KindB)
+		}
+	}
+}
+
+// TestCompareChainClassifications_DifferentLengths_AisLonger verifies that when
+// chainA is longer than chainB, only steps up to len(chainB) are compared.
+// Steps beyond the shorter chain are not compared even if they would diverge.
+func TestCompareChainClassifications_DifferentLengths_AisLonger(t *testing.T) {
+	chainA := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-a-1"),
+		makeClassif(2, loader.DraftMediator, "reason-a-2"),
+		makeClassif(3, loader.DraftTranslation, "reason-a-3"), // no counterpart in B
+	}
+	chainB := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-b-1"), // same
+		makeClassif(2, loader.DraftTranslation, "reason-b-2"),  // differs
+	}
+
+	diffs := loader.CompareChainClassifications(chainA, chainB)
+
+	// Only step 2 diverges; step 3 has no counterpart and must not appear.
+	if len(diffs) != 1 {
+		t.Fatalf("A longer: want 1 diff, got %d: %v", len(diffs), diffs)
+	}
+	if diffs[0].StepIndex != 2 {
+		t.Errorf("diff StepIndex: want 2, got %d", diffs[0].StepIndex)
+	}
+}
+
+// TestCompareChainClassifications_DifferentLengths_BisLonger verifies the
+// symmetric case: when chainB is longer, only steps up to len(chainA) matter.
+func TestCompareChainClassifications_DifferentLengths_BisLonger(t *testing.T) {
+	chainA := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-a-1"), // same
+		makeClassif(2, loader.DraftMediator, "reason-a-2"),     // same
+	}
+	chainB := []loader.DraftStepClassification{
+		makeClassif(1, loader.DraftIntermediary, "reason-b-1"), // same
+		makeClassif(2, loader.DraftMediator, "reason-b-2"),     // same
+		makeClassif(3, loader.DraftTranslation, "reason-b-3"),  // no counterpart in A
+	}
+
+	diffs := loader.CompareChainClassifications(chainA, chainB)
+
+	// Steps 1 and 2 agree; step 3 has no counterpart and must not appear as a diff.
+	if len(diffs) != 0 {
+		t.Errorf("B longer, steps agree: want 0 diffs, got %d: %v", len(diffs), diffs)
+	}
+}
+
+// --- Group 2: PrintClassificationDiffs ---
+
+// TestPrintClassificationDiffs_NoDivergence verifies that when diffs is empty
+// and lengths are equal, the output contains a "No classification divergence"
+// message (or equivalent).
+func TestPrintClassificationDiffs_NoDivergence(t *testing.T) {
+	var buf bytes.Buffer
+	err := loader.PrintClassificationDiffs(&buf, "alice", "bob", 3, 3, []loader.ClassificationDiff{})
+
+	if err != nil {
+		t.Fatalf("PrintClassificationDiffs() returned unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "No classification divergence") &&
+		!strings.Contains(out, "no classification divergence") &&
+		!strings.Contains(out, "No divergence") {
+		t.Errorf("output missing no-divergence message; got:\n%s", out)
+	}
+}
+
+// TestPrintClassificationDiffs_WithDivergence verifies that when there is one
+// diff, the output contains the analyst labels, the step index, and both
+// Kind strings.
+func TestPrintClassificationDiffs_WithDivergence(t *testing.T) {
+	diffs := []loader.ClassificationDiff{
+		{
+			StepIndex: 2,
+			KindA:     loader.DraftMediator,
+			KindB:     loader.DraftTranslation,
+			ReasonA:   "reason from alice",
+			ReasonB:   "reason from bob",
+		},
+	}
+
+	var buf bytes.Buffer
+	err := loader.PrintClassificationDiffs(&buf, "alice", "bob", 3, 3, diffs)
+
+	if err != nil {
+		t.Fatalf("PrintClassificationDiffs() returned unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	// Must contain both analyst labels.
+	if !strings.Contains(out, "alice") {
+		t.Errorf("output missing analyst label %q; got:\n%s", "alice", out)
+	}
+	if !strings.Contains(out, "bob") {
+		t.Errorf("output missing analyst label %q; got:\n%s", "bob", out)
+	}
+
+	// Must reference the step index explicitly as "Step 2" (1-based, matching
+	// the StepIndex in the diff). The bare-digit fallback is intentionally
+	// omitted — "2" appears in many unrelated output lines.
+	if !strings.Contains(out, "Step 2") {
+		t.Errorf("output missing step index 'Step 2'; got:\n%s", out)
+	}
+
+	// Must contain both Kind strings.
+	if !strings.Contains(out, string(loader.DraftMediator)) {
+		t.Errorf("output missing KindA %q; got:\n%s", loader.DraftMediator, out)
+	}
+	if !strings.Contains(out, string(loader.DraftTranslation)) {
+		t.Errorf("output missing KindB %q; got:\n%s", loader.DraftTranslation, out)
+	}
+}
+
+// TestPrintClassificationDiffs_LengthMismatch verifies that when lenA != lenB,
+// the output mentions the difference between the two chain lengths.
+func TestPrintClassificationDiffs_LengthMismatch(t *testing.T) {
+	var buf bytes.Buffer
+	err := loader.PrintClassificationDiffs(&buf, "alice", "bob", 2, 3, []loader.ClassificationDiff{})
+
+	if err != nil {
+		t.Fatalf("PrintClassificationDiffs() returned unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	// Output must name both chain lengths explicitly. Both "2 steps" AND "3 steps"
+	// must be present — an OR would accept output that names only one side.
+	if !strings.Contains(out, "2 steps") || !strings.Contains(out, "3 steps") {
+		t.Errorf("output must name both lengths (2 steps and 3 steps); got:\n%s", out)
+	}
+}
+
+// TestPrintClassificationDiffs_BothLabelsPresent verifies that the output
+// contains both the analystA and analystB label strings in all cases, including
+// when there are no diffs.
+func TestPrintClassificationDiffs_BothLabelsPresent(t *testing.T) {
+	var buf bytes.Buffer
+	err := loader.PrintClassificationDiffs(&buf, "position-alpha", "position-beta", 2, 2, []loader.ClassificationDiff{})
+
+	if err != nil {
+		t.Fatalf("PrintClassificationDiffs() returned unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "position-alpha") {
+		t.Errorf("output missing analystA label %q; got:\n%s", "position-alpha", out)
+	}
+	if !strings.Contains(out, "position-beta") {
+		t.Errorf("output missing analystB label %q; got:\n%s", "position-beta", out)
+	}
+}
+
+// TestPrintClassificationDiffs_NeitherAuthoritative verifies that the output
+// contains a closing note including "Neither" or "authoritative" to signal that
+// no classification position is treated as the ground truth.
+func TestPrintClassificationDiffs_NeitherAuthoritative(t *testing.T) {
+	var buf bytes.Buffer
+	err := loader.PrintClassificationDiffs(&buf, "alice", "bob", 2, 2, []loader.ClassificationDiff{})
+
+	if err != nil {
+		t.Fatalf("PrintClassificationDiffs() returned unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "Neither") && !strings.Contains(out, "neither") &&
+		!strings.Contains(out, "authoritative") {
+		t.Errorf("output missing 'Neither'/'authoritative' disclaimer; got:\n%s", out)
+	}
+}
+
+// classdiffFailWriter is an io.Writer that always fails immediately. Used to
+// verify that PrintClassificationDiffs propagates and wraps write errors.
+type classdiffFailWriter struct{}
+
+func (classdiffFailWriter) Write([]byte) (int, error) { return 0, fmt.Errorf("disk full") }
+
+// TestPrintClassificationDiffs_WriteError verifies that a failing io.Writer
+// causes PrintClassificationDiffs to return a wrapped error that names the
+// function. This guards against silent error-swallowing after a refactor.
+func TestPrintClassificationDiffs_WriteError(t *testing.T) {
+	err := loader.PrintClassificationDiffs(classdiffFailWriter{}, "alice", "bob", 1, 1, []loader.ClassificationDiff{})
+
+	if err == nil {
+		t.Fatal("PrintClassificationDiffs(failWriter): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "PrintClassificationDiffs") {
+		t.Errorf("error should name the function; got: %v", err)
+	}
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -672,9 +672,19 @@ Parent issue: #103
 
 - [x] **C.1 (#104) — Multi-analyst draft set schema** — `GroupByAnalyst` in `loader/analyst.go`; no `AnalystSet` (ExtractedBy sufficient); `ExtractedBy` doc comment clarified as analyst-position cut axis; 7 tests, 100% coverage; PR #109 merged
 - [x] **C.2 (#105) — Extraction gap analysis** — `CompareExtractions`, `ExtractionGap`, `FieldDisagreement`, `PrintExtractionGap` in `loader/extractiongap.go`; `meshant extraction-gap` CLI; 9 content fields (incl. SourceDocRef); 27 tests; PR #110 merged
-- [ ] **C.3 (#106) — Classification comparison** — `CompareChainClassifications`, `ClassificationDiff`, `PrintClassificationDiffs`
+- [x] **C.3 (#106) — Classification comparison** — `CompareChainClassifications`, `ClassificationDiff`, `PrintClassificationDiffs` in `loader/classdiff.go`; `meshant chain-diff` CLI; 14 unit tests in `loader/classdiff_test.go`, 11 integration tests in `cmd/meshant/main_test.go`; PR #111 merged
 - [ ] **C.4 (#107) — Multi-analyst example dataset** — `data/examples/multi_analyst_drafts.json`
 - [ ] **C.5 (#108) — Decision record + docs** — `docs/decisions/multi-analyst-v1.md`, codemap, `tasks/todo.md`
+
+### Deferred Items
+
+Items identified during review but deferred to future work:
+
+- **CLI code organization** — Architect review (C.3): `main.go` and `main_test.go` extraction candidate; trigger on next subcommand addition (current size ~2010 lines, tracking for future per-command file split)
+- **Slice equality helper naming** — Architect review (C.3): naming inconsistency (`slicesEqual`/`stringSlicesEqual`); clearer names deferred to next refactor-clean pass
+- **buildChain closure extraction** — Architect review (C.3): candidate for extraction if a second consumer appears in future work
+
+---
 
 ### Thread D — Real-World Datasets (runs alongside all threads)
 


### PR DESCRIPTION
## Summary

- `loader/classdiff.go` (new): `ClassificationDiff`, `CompareChainClassifications`, `PrintClassificationDiffs`
- `loader/classdiff_test.go` (new): 14 unit tests
- `cmd/meshant/main.go`: `chain-diff` subcommand with `buildChain` span-scoped chain logic
- `cmd/meshant/main_test.go`: 11 integration tests
- `docs/CODEMAPS/meshant.md`, `tasks/todo.md`: updated

## What changed

Adds classification-diff analysis to the ingestion layer — the derivation-chain analogue of `ObserverGap` and `ExtractionGap`. Two analyst positions that extracted the same `SourceSpan` may have produced different derivation chains; `CompareChainClassifications` surfaces steps where they classified the same depth differently. Neither position is treated as authoritative.

Key design decisions:
- `StepIndex` derived from loop counter (`i+1`), not raw input field — avoids silent bugs when caller passes misaligned chains
- `buildChain` uses span-scoped ID set for root-finding, not the full analyst set — prevents cross-span `DerivedFrom` links from misidentifying the chain root
- Explicit errors for ambiguous roots (multiple independent root candidates) and cyclic derivations
- `chain-diff` is a standalone subcommand, not an extension of `extraction-gap` — they answer different analytical questions (what was extracted vs how the chain was classified)

ANT language: output uses "Position A / Position B", "produced the same reading" (not "agree"), and closes with "Neither classification is authoritative. Each reflects where it stands." + step-index identity caveat.

## Reviews passed

- Code reviewer ✓ (3 HIGH issues resolved)
- Security reviewer ✓ (no findings)
- ANT-theorist ✓ (ALIGNED, 2 language fixes applied)
- QA engineer ✓ (4 fixes applied, including ambiguous-root and cycle integration tests)
- Architect ✓ (APPROVED, 3 deferred items documented in todo.md)

## Test plan

- [ ] `go test ./...` — all green
- [ ] `go vet ./...` — clean
- [ ] `meshant chain-diff --analyst-a alice --analyst-b bob --span <span> <drafts.json>` — manual smoke test
- [ ] Error cases: missing flags, unknown analyst, unknown span, ambiguous root, cycle

Closes #106