### PR TITLE
feat: F.2 meshant extract — llm package + extract subcommand (#118)

### DIFF
--- a/docs/CODEMAPS/meshant.md
+++ b/docs/CODEMAPS/meshant.md
@@ -1,6 +1,6 @@
 # MeshAnt — Codemap
 
-**Last Updated:** 2026-03-21 (F.1: LLM mediator convention — decision record, extraction prompt, critiqued stage)
+**Last Updated:** 2026-03-21 (F.2: `meshant extract` subcommand — `llm` package with LLMClient, RunExtraction, SessionRecord)
 **Module:** `github.com/automatedtomato/mesh-ant/meshant`
 **Go Version:** 1.25
 **Root Directory:** `/meshant`
@@ -14,8 +14,9 @@
 | `graph` | Articulate graphs, compute diffs, identify graphs as actors, reflexive tracing, follow translation chains, classify chains, shadow analysis, observer-gap analysis, bottleneck analysis, re-articulation suggestions, narrative drafts, export to JSON/DOT/Mermaid. |
 | `persist` | Read and write graphs to JSON files. |
 | `review` | Ambiguity detection, terminal rendering, and interactive accept/edit/skip/quit session for TraceDraft records (Thread A). |
+| `llm` | LLM-mediated extraction pipeline: `LLMClient` interface, `AnthropicClient`, `RunExtraction`, `SessionRecord`, and supporting types. Enforces F.1 conventions (D1–D7): mediator framing, model-ID provenance, framework UncertaintyNote append, IntentionallyBlank validation (F.2). |
 | `cmd/demo` | Minimal demonstration: two observer-position cuts on evacuation dataset. |
-| `cmd/meshant` | CLI entry point: `summarize`, `validate`, `articulate`, `diff`, `follow`, `draft`, `promote`, `rearticulate`, `lineage`, `shadow`, `gaps`, `bottleneck`, `review` subcommands. `articulate` supports `--narrative` flag; `gaps` supports `--suggest` flag. `review` is the only interactive subcommand (reads from stdin). |
+| `cmd/meshant` | CLI entry point: `summarize`, `validate`, `articulate`, `diff`, `follow`, `draft`, `promote`, `rearticulate`, `lineage`, `shadow`, `gaps`, `bottleneck`, `review`, `extract` subcommands. `articulate` supports `--narrative` flag; `gaps` supports `--suggest` flag. `review` is the only interactive subcommand (reads from stdin). `extract` calls an LLM to produce TraceDraft records from a source document (F.2). |
 
 ## Package: schema
 
@@ -255,6 +256,49 @@ None (persist carries no domain types; wraps graph types).
 | `run` | `func run(w io.Writer, datasetPath string) error` | Full pipeline: Load → Summary → Articulate (Cut A: meteorological-analyst, 2026-04-14) → Articulate (Cut B: local-mayor, 2026-04-16) → Diff → Closing note. |
 | `printClosingNote` | `func printClosingNote(w io.Writer) error` | Write methodological coda naming observer positions, shadows, and Principle 8 gap. |
 
+## Package: llm
+
+### Files
+
+| File | Contains |
+|------|----------|
+| `types.go` | Shared types: `ExtractionConditions`, `DraftDisposition`, `SessionRecord`, `ExtractionOptions`; error types `ErrLLMRefusal`, `ErrMalformedOutput`; constants `frameworkUncertaintyNote`, `maxSourceBytes`, `maxResponseBytes`, `httpTimeout`; `knownContentFields` map. |
+| `client.go` | `LLMClient` interface; `AnthropicClient` implementation (net/http, zero external deps); `NewAnthropicClient()` (env-var key lookup); private `httpClient` with 180 s timeout; response body capped at 8 MiB; auth error scrubbing (401/403 bodies withheld). |
+| `prompt.go` | `LoadPromptTemplate(path)` — reads prompt template up to 1 MiB; empty file is valid (no error). |
+| `extract.go` | `RunExtraction(ctx, client, opts)` — LLM extraction pipeline; always returns non-nil `SessionRecord` even on error; validates `IntentionallyBlank` field names; detects refusals by prefix heuristic; strips LLM preamble before JSON parse; stamps provenance fields (D2–D7). Private helpers: `readSourceDoc`, `isRefusal`, `parseResponse`, `validateIntentionallyBlank`. |
+
+### Types
+
+| Type | Key Fields | Purpose |
+|------|-----------|---------|
+| `LLMClient` | `Complete(ctx, system, prompt string) (string, error)` | Interface for LLM completion. Single method — models the analytical boundary: inputs in, text out. Implemented by `AnthropicClient`; tests inject a mock. |
+| `AnthropicClient` | `apiKey` (unexported), `model`, `baseURL`, `httpClient` | Anthropic Messages API client. API key never serialised or logged. Uses a private `http.Client` with explicit timeout; never `http.DefaultClient`. |
+| `ExtractionConditions` | `ModelID`, `PromptTemplate`, `CriterionRef`, `SystemInstructions`, `SourceDocRef`, `Timestamp` | Apparatus description for one LLM session. Intentionally excludes API key — conditions are written to disk. |
+| `SessionRecord` | `ID` (uuid), `Command` (string), `Conditions` (ExtractionConditions), `DraftIDs` ([]string), `Dispositions` ([]DraftDisposition), `InputPath`, `OutputPath`, `DraftCount`, `ErrorNote`, `Timestamp` | Mandatory companion to every LLM interaction. Returned on every code path. `ID` is stamped as `SessionRef` on every produced draft. `ErrorNote` makes failures inspectable from disk without re-running. |
+| `ExtractionOptions` | `ModelID`, `InputPath`, `PromptTemplatePath`, `CriterionRef`, `SourceDocRef`, `OutputPath`, `SessionOutputPath` | Input parameters for `RunExtraction`. |
+| `ErrLLMRefusal` | `RefusalText string` | LLM explicitly declined to produce output. |
+| `ErrMalformedOutput` | `RawResponse string`, `ParseErr error` | LLM returned text that does not parse as TraceDraft JSON. |
+
+### Functions
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `NewAnthropicClient` | `func NewAnthropicClient(model string) (*AnthropicClient, error)` | Read API key from `MESHANT_LLM_API_KEY` (fallback `ANTHROPIC_API_KEY`); construct client with 180 s timeout. Returns error if both env vars are absent or empty. |
+| `AnthropicClient.Complete` | `(c *AnthropicClient) Complete(ctx, system, prompt string) (string, error)` | Post to Anthropic Messages API; return first text content block. Caps response body at 8 MiB; scrubs auth error bodies. |
+| `LoadPromptTemplate` | `func LoadPromptTemplate(path string) (string, error)` | Read prompt template file up to 1 MiB. Empty file returns `""` without error. |
+| `RunExtraction` | `func RunExtraction(ctx context.Context, client LLMClient, opts ExtractionOptions) ([]schema.TraceDraft, SessionRecord, error)` | Full extraction pipeline: read source doc → load prompt → call LLM → detect refusal → parse JSON → validate/stamp each draft → return drafts + SessionRecord. Always returns non-nil SessionRecord. Stamps D2 (ExtractedBy), D3 (UncertaintyNote append), D4 (ExtractionStage "weak-draft"), D6 (SessionRef), D7 (IntentionallyBlank validation) per F.1 decision record. |
+
+### Key Design Notes
+
+- **Zero external dependencies**: Uses only Go stdlib (`net/http`, `encoding/json`, `io`, `os`, `context`).
+- **SessionRecord is mandatory**: `RunExtraction` always returns a SessionRecord. On error, `ErrorNote` is populated. The caller writes the record to disk; the `llm` package does not own the write.
+- **F.1 convention enforcement**: D2 (ExtractedBy = model ID string), D3 (frameworkUncertaintyNote always appended), D4 (ExtractionStage = "weak-draft"), D6 (SessionRecord mandatory return), D7 (IntentionallyBlank validates against content-field allowlist). See `docs/decisions/llm-as-mediator-v1.md`.
+- **Client injection**: `RunExtraction` accepts `LLMClient` interface — tests inject a mock; production code uses `AnthropicClient`. No live API calls in unit tests.
+- **Refusal detection**: `isRefusal()` matches conservative English-language prefixes. False negatives fall through to the malformed-output path, which is correct. The heuristic is English-only (documented in F.6 deferred notes).
+- **Security**: API key is an unexported struct field; never appears in `SessionRecord`, any error message, or any serialised output. Authentication error responses (401/403) are not echoed to the user.
+
+---
+
 ## Package: cmd/meshant
 
 ### Files
@@ -277,6 +321,7 @@ None (persist carries no domain types; wraps graph types).
 | `cmd_review.go` | `cmdReview` subcommand handler — only interactive subcommand; accepts `in io.Reader` (A.5). |
 | `cmd_extraction_gap.go` | `cmdExtractionGap` subcommand handler (C.2). |
 | `cmd_chain_diff.go` | `cmdChainDiff` subcommand handler (C.3). |
+| `cmd_extract.go` | `cmdExtract` subcommand handler — calls LLM via injected `llm.LLMClient`; writes TraceDraft JSON and SessionRecord JSON; session output defaulting: `<output>.session.json` (file mode) or `session_<timestamp>.json` in cwd (stdout mode) (F.2). |
 | `main_test.go` | Tests: all subcommands, flag parsing, file output, error handling, criterion file loading, draft/promote pipeline (M11). |
 
 ### Types
@@ -294,7 +339,7 @@ None (persist carries no domain types; wraps graph types).
 | `parseTimeFlag` | `func parseTimeFlag(name, value string) (time.Time, error)` | Parse RFC3339 string to time.Time with contextual error message naming the flag. |
 | `parseTimeWindow` | `func parseTimeWindow(fromName, fromStr, toName, toStr string) (graph.TimeWindow, error)` | Parse two RFC3339 strings (one or both may be empty) into a TimeWindow. Validates only when both bounds are set. |
 | `main` | `func main()` | Entry point. Calls `run(os.Stdout, os.Args[1:])` and exits non-zero on error. |
-| `run` | `func run(w io.Writer, args []string) error` | Command dispatcher. Parses args to identify subcommand and flags; routes to `cmdSummarize()`, `cmdValidate()`, `cmdArticulate()`, `cmdDiff()`, `cmdFollow()`, `cmdDraft()`, `cmdPromote()`, `cmdRearticulate()`, `cmdLineage()`, `cmdShadow()`, `cmdGaps()`, `cmdBottleneck()`, `cmdExtractionGap()`, `cmdChainDiff()`, or `cmdReview()`. For the `review` case, passes `os.Stdin` as the reader to `cmdReview`. |
+| `run` | `func run(w io.Writer, args []string) error` | Command dispatcher. Routes to `cmdSummarize()`, `cmdValidate()`, `cmdArticulate()`, `cmdDiff()`, `cmdFollow()`, `cmdDraft()`, `cmdPromote()`, `cmdRearticulate()`, `cmdLineage()`, `cmdShadow()`, `cmdGaps()`, `cmdBottleneck()`, `cmdExtractionGap()`, `cmdChainDiff()`, `cmdReview()`, or `cmdExtract()`. For `review`, passes `os.Stdin`; for `extract`, passes `nil` (real client constructed from env). |
 | `cmdSummarize` | `func cmdSummarize(w io.Writer, args []string) error` | Subcommand: Load traces, compute mesh summary, print via `loader.PrintSummary()`. Usage: `meshant summarize <file>`. |
 | `cmdValidate` | `func cmdValidate(w io.Writer, args []string) error` | Subcommand: Load and validate traces. Reports success message or errors. Usage: `meshant validate <file>`. |
 | `cmdArticulate` | `func cmdArticulate(w io.Writer, args []string) error` | Subcommand: Load traces, articulate a cut with `--observer` (repeatable), `--tag` (repeatable, any-match), `--from`, `--to` (RFC3339), `--format text\|json\|dot\|mermaid`, `--output <file>`. Optional `--narrative` flag appends a positioned narrative draft (text format only, skipped for JSON/DOT/Mermaid). |
@@ -310,6 +355,8 @@ None (persist carries no domain types; wraps graph types).
 | `cmdExtractionGap` | `func cmdExtractionGap(w io.Writer, args []string) error` | Subcommand: Load two TraceDraft JSON files, compare extractions from named positions via `loader.CompareExtractions()`, print gap report via `PrintExtractionGap()`. Flags: `--analyst-a <label>`, `--analyst-b <label>` (both required, names of analyst positions), `--output <file>` (C.2). |
 | `cmdChainDiff` | `func cmdChainDiff(w io.Writer, args []string) error` | Subcommand: Load TraceDraft JSON, build span-scoped derivation chains for two named analyst positions via `loader.FollowDraftChain()` + `loader.ClassifyDraftChain()`, compare classifications via `loader.CompareChainClassifications()`, print diff report via `PrintClassificationDiffs()`. Flags: `--analyst-a <label>`, `--analyst-b <label>` (both required), `--span <source_span>` (required), `--output <file>` (C.3). |
 | `cmdReview` | `func cmdReview(w io.Writer, in io.Reader, args []string) error` | Subcommand: Load TraceDraft JSON, run interactive accept/edit/skip/quit session via `review.RunReviewSession()`. Only interactive subcommand — signature diverges from all other `cmd*` functions by accepting `in io.Reader` for stdin injection (testability). Interactive prompts go to `os.Stderr`; JSON output and summary go to `w`. Flags: `--output <file>` (A.5). |
+| `cmdExtract` | `func cmdExtract(w io.Writer, client llm.LLMClient, args []string) error` | Subcommand: Call LLM to produce TraceDraft records from a source document. Accepts an injected `llm.LLMClient` (nil = construct `AnthropicClient` from env). Writes TraceDraft JSON array and a `SessionRecord` JSON file on every code path (success and error). Session output defaulting: `<output>.session.json` when `--output` is a file; `session_<timestamp>.json` in cwd when stdout. Flags: `--source-doc <path>` (required), `--source-doc-ref <ref>`, `--prompt-template <path>` (default: `data/prompts/extraction_pass.md`), `--model <id>` (default: `claude-sonnet-4-6`), `--criterion-file <path>`, `--output <file>`, `--session-output <file>` (F.2). |
+| `writeSessionRecord` | `func writeSessionRecord(path string, rec llm.SessionRecord) error` | Serialise SessionRecord as indented JSON to path. Encodes to buffer first; creates file only on success (avoids empty file on encode failure). Used only by `cmdExtract`. |
 | `loadCriterionFile` | `func loadCriterionFile(path string) (graph.EquivalenceCriterion, error)` | Load, decode, and validate an EquivalenceCriterion from a JSON file. Uses `DisallowUnknownFields()` for precision. Zero-value criterion is a hard error. Returns validated criterion or descriptive error. |
 | `outputWriter` | `func outputWriter(w io.Writer, outputPath string) (io.Writer, error)` | Return file writer if `--output` is set, otherwise stdout. |
 | `confirmOutput` | `func confirmOutput(w io.Writer, outputPath string) error` | Print "wrote <path>" confirmation to stdout when file output is used. |
@@ -324,6 +371,7 @@ None (persist carries no domain types; wraps graph types).
 - **Format options**: `articulate` and `diff` both support text/json/dot/mermaid; `follow` supports text/json
 - **File output**: `--output <file>` writes to file instead of stdout; `cmdReview` uses explicit `f.Close()` (not deferred) to surface write errors
 - **Interactive subcommand**: `cmdReview` is the only `cmd*` function that accepts `in io.Reader` — all other subcommands are non-interactive. `run()` passes `os.Stdin` for the review case only. If a second interactive subcommand is added, migrate to a `cmdContext` struct rather than adding more signature exceptions.
+- **LLM-injected subcommand**: `cmdExtract` accepts `llm.LLMClient` as a parameter (nil = real client from env). This is the same injection pattern as `cmdReview`'s `io.Reader` — enables testing without live API calls. `run()` passes `nil`; tests pass a mock (F.2).
 - **Stderr/stdout separation**: `cmdReview` writes interactive prompts to `os.Stderr` and JSON output to `w` (stdout), enabling `meshant review file.json | jq .` and `--output` file routing without prompt contamination.
 - **Ingestion pipeline** (M11): `draft` command ingests LLM extraction JSON and produces TraceDraft records; `promote` command converts promotable TraceDraft records to canonical Traces (tagged with `draft` provenance signal)
 - **Re-articulation pipeline** (M12): `rearticulate` command produces critique skeletons (SourceSpan + DerivedFrom set, all content fields blank); `lineage` command walks DerivedFrom links and renders positional reading sequences as CLI output
@@ -351,6 +399,10 @@ graph/
 persist/
   ├─→ imports: graph
   └─→ (used by) external tools/pipelines
+
+llm/
+  ├─→ imports: schema (TraceDraft), loader (NewUUID)
+  └─→ (used by) cmd/meshant
 
 cmd/demo/
   ├─→ imports: graph, loader
@@ -387,6 +439,16 @@ cmd/demo/
 5. Returns `GraphDiff` with empty ID (not an actor yet)
 6. Optional: `graph.IdentifyDiff(d)` → assigns UUID
 7. Optional: `graph.DiffTrace(d, g1, g2, observer)` → records diff as reflexive Trace
+
+### LLM Extraction Pipeline (F.2)
+1. `cmdExtract` validates flags; resolves `sessionOutputPath` (defaulting rules)
+2. `llm.RunExtraction(ctx, client, opts)` — called with injected or real client
+3. Inside: read source doc (capped at 1 MiB) → load prompt template → call `client.Complete()`
+4. Detect refusal via prefix heuristic → parse JSON array (strips LLM preamble)
+5. Per draft: validate `IntentionallyBlank`, assign UUID, stamp D2/D3/D4/D6/D7 fields
+6. Return `[]TraceDraft + SessionRecord` (always non-nil, even on error)
+7. `cmdExtract` writes SessionRecord JSON first (always), then TraceDraft JSON, then summary
+8. On error: SessionRecord with ErrorNote is on disk; extraction error returned to caller
 
 ### Demo Pipeline (cmd/demo/main.go)
 1. Load evacuation_order.json

--- a/meshant/cmd/meshant/cmd_extract.go
+++ b/meshant/cmd/meshant/cmd_extract.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/automatedtomato/mesh-ant/meshant/llm"
+	"github.com/automatedtomato/mesh-ant/meshant/loader"
+)
+
+// defaultExtractionPrompt is the path to the bundled extraction prompt
+// template, relative to the repository root. It is used when --prompt-template
+// is not supplied.
+const defaultExtractionPrompt = "data/prompts/extraction_pass.md"
+
+// defaultExtractModel is the model ID used when --model is not supplied.
+const defaultExtractModel = "claude-sonnet-4-6"
+
+// cmdExtract implements the "extract" subcommand.
+//
+// It calls the LLM to produce TraceDraft records from a source document,
+// then writes two outputs:
+//  1. TraceDraft JSON array to --output (or stdout)
+//  2. SessionRecord JSON to --session-output (see defaulting rules below)
+//
+// The LLM client is injected via the client parameter. When client is nil,
+// cmdExtract constructs a real AnthropicClient from the environment (reading
+// MESHANT_LLM_API_KEY or ANTHROPIC_API_KEY). Tests pass a mock client so the
+// extraction pipeline is exercised without live API calls.
+//
+// Session output defaulting:
+//   - if --session-output is provided: write to that path
+//   - if --output is a file: write to <output>.session.json
+//   - if output is stdout: write to session_<compact-ISO8601-timestamp>.json in cwd
+//
+// Flags:
+//   - --source-doc <path>         path to source document (required)
+//   - --source-doc-ref <ref>      document reference string for provenance (defaults to --source-doc path)
+//   - --prompt-template <path>    path to extraction prompt template (default: data/prompts/extraction_pass.md)
+//   - --model <id>                LLM model ID (default: claude-sonnet-4-6)
+//   - --criterion-file <path>     optional criterion JSON file (CriterionRef provenance)
+//   - --output <file>             write TraceDraft JSON to file (default: stdout)
+//   - --session-output <file>     write SessionRecord JSON to file (see defaulting above)
+func cmdExtract(w io.Writer, client llm.LLMClient, args []string) error {
+	fs := flag.NewFlagSet("extract", flag.ContinueOnError)
+
+	var sourceDoc string
+	fs.StringVar(&sourceDoc, "source-doc", "", "path to source document (required)")
+
+	var sourceDocRef string
+	fs.StringVar(&sourceDocRef, "source-doc-ref", "", "document reference string for provenance (defaults to --source-doc path)")
+
+	var promptTemplate string
+	fs.StringVar(&promptTemplate, "prompt-template", defaultExtractionPrompt, "path to extraction prompt template")
+
+	var modelID string
+	fs.StringVar(&modelID, "model", defaultExtractModel, "LLM model ID")
+
+	var criterionFile string
+	fs.StringVar(&criterionFile, "criterion-file", "", "path to criterion JSON file (optional)")
+
+	var outputPath string
+	fs.StringVar(&outputPath, "output", "", "write TraceDraft JSON to file (default: stdout)")
+
+	var sessionOutputPath string
+	fs.StringVar(&sessionOutputPath, "session-output", "", "write SessionRecord JSON to file (see default rules)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if sourceDoc == "" {
+		return fmt.Errorf("extract: --source-doc is required\n\nUsage: meshant extract --source-doc <path> [--source-doc-ref <ref>] [--prompt-template <path>] [--model <id>] [--criterion-file <path>] [--output <file>] [--session-output <file>]")
+	}
+
+	// sourceDocRef defaults to the source document path when not provided.
+	if sourceDocRef == "" {
+		sourceDocRef = sourceDoc
+	}
+
+	// Derive sessionOutputPath from outputPath when not explicitly provided.
+	// For a file output, use <output>.session.json.
+	// For stdout, use session_<timestamp>.json in the current directory.
+	if sessionOutputPath == "" {
+		if outputPath != "" {
+			sessionOutputPath = outputPath + ".session.json"
+		} else {
+			sessionOutputPath = "session_" + time.Now().UTC().Format("20060102T150405Z") + ".json"
+		}
+	}
+
+	// Resolve criterion reference string from optional --criterion-file.
+	var criterionRef string
+	if criterionFile != "" {
+		c, err := loadCriterionFile(criterionFile)
+		if err != nil {
+			return fmt.Errorf("extract: %w", err)
+		}
+		criterionRef = c.Name
+	}
+
+	// Construct real LLM client from environment when none is injected.
+	if client == nil {
+		c, err := llm.NewAnthropicClient(modelID)
+		if err != nil {
+			return fmt.Errorf("extract: %w", err)
+		}
+		client = c
+	}
+
+	opts := llm.ExtractionOptions{
+		ModelID:            modelID,
+		InputPath:          sourceDoc,
+		PromptTemplatePath: promptTemplate,
+		CriterionRef:       criterionRef,
+		SourceDocRef:       sourceDocRef,
+		OutputPath:         outputPath,
+		SessionOutputPath:  sessionOutputPath,
+	}
+
+	drafts, rec, err := llm.RunExtraction(context.Background(), client, opts)
+
+	// Always write the SessionRecord before returning — even on extraction error.
+	// The session record carries ErrorNote so failures are inspectable from disk
+	// without re-running. When the extraction succeeded but the session write
+	// fails, that is a hard error: the provenance record is lost.
+	sessionWriteErr := writeSessionRecord(sessionOutputPath, rec)
+	if err != nil {
+		// Primary extraction error takes precedence; demote session-write failure
+		// to a warning so the extraction error is not masked.
+		if sessionWriteErr != nil {
+			fmt.Fprintf(w, "extract: warning: could not write session record to %q: %v\n", sessionOutputPath, sessionWriteErr)
+		}
+		return fmt.Errorf("extract: %w", err)
+	}
+	if sessionWriteErr != nil {
+		// Extraction succeeded but session record lost — provenance is broken.
+		return fmt.Errorf("extract: write session record: %w", sessionWriteErr)
+	}
+
+	// Write TraceDraft JSON array to output destination.
+	dest, err := outputWriter(w, outputPath)
+	if err != nil {
+		return fmt.Errorf("extract: %w", err)
+	}
+	if f, ok := dest.(*os.File); ok {
+		defer f.Close()
+	}
+
+	enc := json.NewEncoder(dest)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(drafts); err != nil {
+		return fmt.Errorf("extract: encode output: %w", err)
+	}
+
+	// Print a provenance summary to w (always stdout) — never to the output
+	// file. This mirrors cmdDraft's behaviour.
+	summary := loader.SummariseDrafts(drafts)
+	if err := loader.PrintDraftSummary(w, summary); err != nil {
+		return fmt.Errorf("extract: %w", err)
+	}
+
+	// Confirm file output paths.
+	if err := confirmOutput(w, outputPath); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "wrote session record to %s\n", sessionOutputPath)
+	return err
+}
+
+// writeSessionRecord serialises rec as indented JSON to path.
+// It encodes to a buffer before creating the file so that a serialisation
+// failure does not leave an empty or truncated file on disk.
+// Used only by cmdExtract; move to main.go when other commands need session persistence.
+func writeSessionRecord(path string, rec llm.SessionRecord) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(rec); err != nil {
+		return fmt.Errorf("encode session record: %w", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return nil
+}

--- a/meshant/cmd/meshant/cmd_extract_test.go
+++ b/meshant/cmd/meshant/cmd_extract_test.go
@@ -1,0 +1,498 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/llm"
+	"github.com/automatedtomato/mesh-ant/meshant/schema"
+)
+
+// extractMockClient is a minimal llm.LLMClient test double for cmdExtract
+// tests. It returns a canned response or error on each call.
+type extractMockClient struct {
+	response string
+	err      error
+}
+
+func (m *extractMockClient) Complete(_ context.Context, _, _ string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.response, nil
+}
+
+// writeExtractSourceDoc writes content to a temp file and returns its path.
+func writeExtractSourceDoc(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "source.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeExtractSourceDoc: %v", err)
+	}
+	return path
+}
+
+// writeExtractPromptTemplate writes a minimal prompt template and returns its path.
+func writeExtractPromptTemplate(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(path, []byte("Extract trace drafts."), 0o644); err != nil {
+		t.Fatalf("writeExtractPromptTemplate: %v", err)
+	}
+	return path
+}
+
+// twoValidDrafts is a JSON response returning two well-formed TraceDraft records.
+const twoValidDrafts = `[
+  {"source_span": "The service went down at 09:00.", "what_changed": "service failure"},
+  {"source_span": "Service restored at 09:45.", "what_changed": "service restored"}
+]`
+
+// --- Group: cmdExtract ---
+
+// TestCmdExtract_MissingSourceDoc verifies that cmdExtract returns an error
+// containing "required" when --source-doc is not provided.
+func TestCmdExtract_MissingSourceDoc(t *testing.T) {
+	var buf bytes.Buffer
+	client := &extractMockClient{response: twoValidDrafts}
+	err := cmdExtract(&buf, client, []string{})
+	if err == nil {
+		t.Fatal("cmdExtract() with no --source-doc: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should mention required: %v", err)
+	}
+}
+
+// TestCmdExtract_HappyPath verifies that cmdExtract writes a TraceDraft JSON
+// array and a SessionRecord JSON file when the LLM returns valid output.
+func TestCmdExtract_HappyPath(t *testing.T) {
+	src := writeExtractSourceDoc(t, "The service went down at 09:00. Service restored at 09:45.")
+	prompt := writeExtractPromptTemplate(t)
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "drafts.json")
+	sessionPath := filepath.Join(dir, "session.json")
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: twoValidDrafts}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--output", outputPath,
+		"--session-output", sessionPath,
+	})
+	if err != nil {
+		t.Fatalf("cmdExtract() returned unexpected error: %v", err)
+	}
+
+	// Drafts file must exist and parse to 2 records.
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	var drafts []schema.TraceDraft
+	if err := json.Unmarshal(data, &drafts); err != nil {
+		t.Fatalf("output file is not valid JSON: %v", err)
+	}
+	if len(drafts) != 2 {
+		t.Errorf("want 2 drafts, got %d", len(drafts))
+	}
+
+	// Session file must exist and have non-empty ID.
+	sdata, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("session file not created: %v", err)
+	}
+	var rec llm.SessionRecord
+	if err := json.Unmarshal(sdata, &rec); err != nil {
+		t.Fatalf("session file is not valid JSON: %v", err)
+	}
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty")
+	}
+	if rec.DraftCount != 2 {
+		t.Errorf("SessionRecord.DraftCount: want 2, got %d", rec.DraftCount)
+	}
+	if rec.ErrorNote != "" {
+		t.Errorf("SessionRecord.ErrorNote should be empty on success, got %q", rec.ErrorNote)
+	}
+
+	// w output should confirm the file was written.
+	out := buf.String()
+	if !strings.Contains(out, outputPath) {
+		t.Errorf("stdout should mention output path; got: %q", out)
+	}
+}
+
+// TestCmdExtract_EmptyResponse verifies that a "[]" LLM response produces an
+// empty drafts file and a valid session record without error.
+func TestCmdExtract_EmptyResponse(t *testing.T) {
+	src := writeExtractSourceDoc(t, "Some text.")
+	prompt := writeExtractPromptTemplate(t)
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "drafts.json")
+	sessionPath := filepath.Join(dir, "session.json")
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: "[]"}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--output", outputPath,
+		"--session-output", sessionPath,
+	})
+	if err != nil {
+		t.Fatalf("cmdExtract() with empty response: want no error, got: %v", err)
+	}
+
+	data, _ := os.ReadFile(outputPath)
+	var drafts []schema.TraceDraft
+	if err := json.Unmarshal(data, &drafts); err != nil {
+		t.Fatalf("output JSON invalid: %v", err)
+	}
+	if len(drafts) != 0 {
+		t.Errorf("want 0 drafts, got %d", len(drafts))
+	}
+
+	// Session file must still be written.
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Errorf("session file must be written even for empty response: %v", err)
+	}
+}
+
+// TestCmdExtract_ClientError verifies that when the LLM client returns an
+// error, cmdExtract returns an error and still writes the session record with
+// a populated ErrorNote.
+func TestCmdExtract_ClientError(t *testing.T) {
+	src := writeExtractSourceDoc(t, "Some text.")
+	prompt := writeExtractPromptTemplate(t)
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+
+	var buf bytes.Buffer
+	client := &extractMockClient{err: errors.New("network timeout")}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--session-output", sessionPath,
+	})
+	if err == nil {
+		t.Fatal("cmdExtract() with client error: want error, got nil")
+	}
+
+	// Session record must be written even on error.
+	sdata, readErr := os.ReadFile(sessionPath)
+	if readErr != nil {
+		t.Fatalf("session file must exist even on error: %v", readErr)
+	}
+	var rec llm.SessionRecord
+	if err := json.Unmarshal(sdata, &rec); err != nil {
+		t.Fatalf("session file is not valid JSON: %v", err)
+	}
+	if rec.ErrorNote == "" {
+		t.Error("SessionRecord.ErrorNote must be set on client error")
+	}
+}
+
+// TestCmdExtract_Refusal verifies that an LLM refusal response produces an
+// ErrLLMRefusal-typed error and still writes the session record with ErrorNote.
+func TestCmdExtract_Refusal(t *testing.T) {
+	src := writeExtractSourceDoc(t, "Some text.")
+	prompt := writeExtractPromptTemplate(t)
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: "I cannot assist with this request."}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--session-output", sessionPath,
+	})
+	if err == nil {
+		t.Fatal("cmdExtract() with refusal: want error, got nil")
+	}
+
+	// The wrapped error chain must contain ErrLLMRefusal.
+	var refusal *llm.ErrLLMRefusal
+	if !errors.As(err, &refusal) {
+		t.Errorf("want ErrLLMRefusal in error chain, got %T: %v", err, err)
+	}
+
+	// Session record must exist with ErrorNote.
+	sdata, readErr := os.ReadFile(sessionPath)
+	if readErr != nil {
+		t.Fatalf("session file must exist on refusal: %v", readErr)
+	}
+	var rec llm.SessionRecord
+	if err := json.Unmarshal(sdata, &rec); err != nil {
+		t.Fatalf("session JSON invalid: %v", err)
+	}
+	if rec.ErrorNote == "" {
+		t.Error("SessionRecord.ErrorNote must be set on refusal")
+	}
+}
+
+// TestCmdExtract_SessionOutputDefaulting_WithOutputFile verifies that when
+// --output is provided and --session-output is omitted, the session file is
+// written to <output>.session.json and contains valid JSON.
+func TestCmdExtract_SessionOutputDefaulting_WithOutputFile(t *testing.T) {
+	src := writeExtractSourceDoc(t, "Service failure at noon.")
+	prompt := writeExtractPromptTemplate(t)
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "out.json")
+	expectedSession := outputPath + ".session.json"
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: `[{"source_span":"Service failure at noon."}]`}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--output", outputPath,
+		// --session-output intentionally omitted
+	})
+	if err != nil {
+		t.Fatalf("cmdExtract() returned error: %v", err)
+	}
+
+	// Session file must exist and contain a valid SessionRecord.
+	sdata, readErr := os.ReadFile(expectedSession)
+	if readErr != nil {
+		t.Fatalf("expected session file %q was not created: %v", expectedSession, readErr)
+	}
+	var rec llm.SessionRecord
+	if err := json.Unmarshal(sdata, &rec); err != nil {
+		t.Fatalf("session file is not valid JSON: %v", err)
+	}
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty in defaulted session file")
+	}
+}
+
+// TestCmdExtract_SessionOutputDefaulting_Stdout verifies that when neither
+// --output nor --session-output is provided, a session_*.json file is written
+// to the current working directory.
+//
+// NOTE: This test uses os.Chdir and is NOT parallel-safe. Do not add
+// t.Parallel() to this test without changing the session-output defaulting
+// implementation to avoid cwd-relative paths.
+func TestCmdExtract_SessionOutputDefaulting_Stdout(t *testing.T) {
+	src := writeExtractSourceDoc(t, "Cache expired.")
+	prompt := writeExtractPromptTemplate(t)
+
+	// Change to a temp dir so the cwd-relative session file lands there.
+	// Restore the original cwd via t.Cleanup regardless of test outcome.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("os.Chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) }) //nolint:errcheck
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: `[{"source_span":"Cache expired."}]`}
+	err = cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		// --output and --session-output both omitted
+	})
+	if err != nil {
+		t.Fatalf("cmdExtract() stdout mode returned error: %v", err)
+	}
+
+	// A session_*.json file must have been created in tmpDir.
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var sessionFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "session_") && strings.HasSuffix(e.Name(), ".json") {
+			sessionFile = filepath.Join(tmpDir, e.Name())
+			break
+		}
+	}
+	if sessionFile == "" {
+		t.Fatal("no session_*.json file created in cwd for stdout mode")
+	}
+	sdata, _ := os.ReadFile(sessionFile)
+	var rec llm.SessionRecord
+	if err := json.Unmarshal(sdata, &rec); err != nil {
+		t.Fatalf("session JSON invalid: %v", err)
+	}
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty")
+	}
+}
+
+// TestCmdExtract_OutputToFile verifies that the TraceDraft JSON written to the
+// output file has all framework provenance fields stamped by RunExtraction.
+func TestCmdExtract_OutputToFile(t *testing.T) {
+	src := writeExtractSourceDoc(t, "The deployment failed.")
+	prompt := writeExtractPromptTemplate(t)
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "drafts.json")
+	sessionPath := filepath.Join(dir, "session.json")
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: `[{"source_span":"The deployment failed.","observer":"ops-team"}]`}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--model", "claude-haiku-4-5",
+		"--output", outputPath,
+		"--session-output", sessionPath,
+	})
+	if err != nil {
+		t.Fatalf("cmdExtract() returned error: %v", err)
+	}
+
+	data, _ := os.ReadFile(outputPath)
+	var drafts []schema.TraceDraft
+	if err := json.Unmarshal(data, &drafts); err != nil {
+		t.Fatalf("output JSON invalid: %v", err)
+	}
+	if len(drafts) != 1 {
+		t.Fatalf("want 1 draft, got %d", len(drafts))
+	}
+	d := drafts[0]
+	if d.ExtractedBy != "claude-haiku-4-5" {
+		t.Errorf("ExtractedBy: want %q, got %q", "claude-haiku-4-5", d.ExtractedBy)
+	}
+	if d.ExtractionStage != "weak-draft" {
+		t.Errorf("ExtractionStage: want %q, got %q", "weak-draft", d.ExtractionStage)
+	}
+	if d.SessionRef == "" {
+		t.Error("SessionRef must be non-empty")
+	}
+	if !strings.Contains(d.UncertaintyNote, "LLM-produced candidate; unverified by human review") {
+		t.Errorf("UncertaintyNote missing framework suffix: %q", d.UncertaintyNote)
+	}
+
+	// Session record must reference the same ID.
+	sdata, _ := os.ReadFile(sessionPath)
+	var rec llm.SessionRecord
+	if err := json.Unmarshal(sdata, &rec); err != nil {
+		t.Fatalf("session JSON invalid: %v", err)
+	}
+	if d.SessionRef != rec.ID {
+		t.Errorf("draft.SessionRef %q != SessionRecord.ID %q", d.SessionRef, rec.ID)
+	}
+}
+
+// TestCmdExtract_SourceDocRef_DefaultsToPath verifies that when --source-doc-ref
+// is omitted, the SourceDocRef on each draft defaults to the source doc path.
+func TestCmdExtract_SourceDocRef_DefaultsToPath(t *testing.T) {
+	src := writeExtractSourceDoc(t, "Network partition observed.")
+	prompt := writeExtractPromptTemplate(t)
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "drafts.json")
+	sessionPath := filepath.Join(dir, "session.json")
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: `[{"source_span":"Network partition observed."}]`}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--output", outputPath,
+		"--session-output", sessionPath,
+	})
+	if err != nil {
+		t.Fatalf("cmdExtract() returned error: %v", err)
+	}
+
+	data, _ := os.ReadFile(outputPath)
+	var drafts []schema.TraceDraft
+	if err := json.Unmarshal(data, &drafts); err != nil {
+		t.Fatalf("output JSON invalid: %v", err)
+	}
+	if len(drafts) != 1 {
+		t.Fatalf("want 1 draft, got %d", len(drafts))
+	}
+	if drafts[0].SourceDocRef != src {
+		t.Errorf("SourceDocRef: want %q (source path), got %q", src, drafts[0].SourceDocRef)
+	}
+}
+
+// writeMinimalCriterionFile writes a minimal valid criterion JSON and returns its path.
+// A name-only criterion is the simplest valid form (no Declaration required for
+// a transport handle, per graph.EquivalenceCriterion design notes).
+func writeMinimalCriterionFile(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "criterion.json")
+	content := `{"name":"` + name + `"}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeMinimalCriterionFile: %v", err)
+	}
+	return path
+}
+
+// TestCmdExtract_CriterionFile_HappyPath verifies that passing --criterion-file
+// propagates the criterion's Name into the session record's CriterionRef.
+func TestCmdExtract_CriterionFile_HappyPath(t *testing.T) {
+	src := writeExtractSourceDoc(t, "Load balancer failed.")
+	prompt := writeExtractPromptTemplate(t)
+	criterion := writeMinimalCriterionFile(t, "ops-incident-criterion")
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "drafts.json")
+	sessionPath := filepath.Join(dir, "session.json")
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: `[{"source_span":"Load balancer failed."}]`}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--criterion-file", criterion,
+		"--output", outputPath,
+		"--session-output", sessionPath,
+	})
+	if err != nil {
+		t.Fatalf("cmdExtract() with --criterion-file returned error: %v", err)
+	}
+
+	// CriterionRef is recorded in the session record conditions, not on drafts.
+	sdata, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("session file not created: %v", err)
+	}
+	var rec llm.SessionRecord
+	if err := json.Unmarshal(sdata, &rec); err != nil {
+		t.Fatalf("session JSON invalid: %v", err)
+	}
+	if rec.Conditions.CriterionRef != "ops-incident-criterion" {
+		t.Errorf("Conditions.CriterionRef: want %q, got %q", "ops-incident-criterion", rec.Conditions.CriterionRef)
+	}
+}
+
+// TestCmdExtract_CriterionFile_Missing verifies that passing a nonexistent path
+// to --criterion-file returns an error containing "criterion-file".
+func TestCmdExtract_CriterionFile_Missing(t *testing.T) {
+	src := writeExtractSourceDoc(t, "Some text.")
+	prompt := writeExtractPromptTemplate(t)
+
+	var buf bytes.Buffer
+	client := &extractMockClient{response: twoValidDrafts}
+	err := cmdExtract(&buf, client, []string{
+		"--source-doc", src,
+		"--prompt-template", prompt,
+		"--criterion-file", "/nonexistent/criterion.json",
+	})
+	if err == nil {
+		t.Fatal("cmdExtract() with missing --criterion-file: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "criterion-file") {
+		t.Errorf("error should mention criterion-file: %v", err)
+	}
+}

--- a/meshant/cmd/meshant/main.go
+++ b/meshant/cmd/meshant/main.go
@@ -14,6 +14,7 @@
 //   - review:          interactively accept/edit/skip weak-draft records (A.5)
 //   - extraction-gap:  compare extraction positions across a shared draft set (C.2)
 //   - chain-diff:      compare derivation-chain classifications across two analyst positions (C.3)
+//   - extract:         call an LLM to produce TraceDraft records from a source document (F.2)
 //
 // The testable logic lives in run() and each cmd* function. main() itself is
 // a thin wrapper that wires os.Stdout and os.Args, then exits non-zero on
@@ -226,6 +227,10 @@ func run(w io.Writer, args []string) error {
 		// the terminal. The extra in parameter keeps the session testable
 		// without a real terminal — tests pass a strings.Reader instead.
 		return cmdReview(w, os.Stdin, args[1:])
+	case "extract":
+		// cmdExtract receives a nil client so the real AnthropicClient is
+		// constructed from env vars at runtime. Tests inject a mock client.
+		return cmdExtract(w, nil, args[1:])
 	default:
 		return fmt.Errorf("unknown command %q\n\n%s", args[0], usage())
 	}
@@ -254,6 +259,7 @@ Commands:
   review          interactively accept/edit/skip weak-draft records (flags: --output)
   extraction-gap  compare extraction positions across a shared draft set (flags: --analyst-a, --analyst-b, --output)
   chain-diff      compare derivation-chain classifications across two analyst positions (flags: --analyst-a, --analyst-b, --span, --output)
+  extract         call LLM to produce TraceDraft records from a source document (flags: --source-doc, --source-doc-ref, --prompt-template, --model, --criterion-file, --output, --session-output)
 
 Run 'meshant <command> --help' for command-specific flags.`
 }

--- a/meshant/llm/client.go
+++ b/meshant/llm/client.go
@@ -1,0 +1,150 @@
+// client.go defines the LLMClient interface and AnthropicClient implementation.
+//
+// The interface has a single method — Complete — that sends system instructions
+// and a user prompt and returns the LLM's text response. The single-method
+// design makes the LLM's analytical boundary explicit: what enters, what exits.
+// The LLM's internal transformations are not visible through this boundary
+// (T2 in docs/decisions/llm-as-mediator-v1.md).
+//
+// AnthropicClient implements LLMClient using the Anthropic Messages API via
+// net/http. No external SDK is used; the project maintains zero external
+// dependencies. The API key is consumed at construction time and never exposed
+// through any exported field or method.
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// LLMClient is the interface for LLM completion calls. Implementing this
+// interface is sufficient for all llm package operations; tests inject a
+// mock, production code uses AnthropicClient.
+type LLMClient interface {
+	Complete(ctx context.Context, system, prompt string) (string, error)
+}
+
+// httpTimeout is the end-to-end timeout for a single Anthropic API call.
+// Large extraction responses (max_tokens: 4096) can be slow; 180 s is generous
+// without allowing a network hang to block indefinitely.
+const httpTimeout = 180 * time.Second
+
+// maxResponseBytes caps the response body read from the Anthropic API.
+// 8 MiB comfortably exceeds the maximum expected response size for a
+// 4096-token completion while bounding memory use if the server misbehaves.
+const maxResponseBytes = 8 * 1024 * 1024
+
+// AnthropicClient implements LLMClient using the Anthropic Messages API.
+// The API key is held in an unexported field and is never serialised,
+// logged, or returned through any exported method.
+type AnthropicClient struct {
+	apiKey     string       // unexported: never in SessionRecord or any output
+	model      string
+	baseURL    string
+	httpClient *http.Client // private client with explicit timeout; never http.DefaultClient
+}
+
+// NewAnthropicClient constructs a client ready to call the Anthropic API.
+// It reads the API key from the environment: MESHANT_LLM_API_KEY is checked
+// first; ANTHROPIC_API_KEY is used as a fallback. Returns a descriptive
+// error if both are absent or empty.
+func NewAnthropicClient(model string) (*AnthropicClient, error) {
+	key := os.Getenv("MESHANT_LLM_API_KEY")
+	if key == "" {
+		key = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if key == "" {
+		return nil, fmt.Errorf("llm: API key required — set MESHANT_LLM_API_KEY (or ANTHROPIC_API_KEY as fallback)")
+	}
+	return &AnthropicClient{
+		apiKey:     key,
+		model:      model,
+		baseURL:    "https://api.anthropic.com",
+		httpClient: &http.Client{Timeout: httpTimeout},
+	}, nil
+}
+
+// Complete sends a Messages API request to Anthropic and returns the text
+// content of the first content block in the response. It uses the model
+// specified at construction time.
+//
+// The system parameter is sent as the system prompt (extraction instructions);
+// the prompt parameter is sent as the single user message (source document).
+func (c *AnthropicClient) Complete(ctx context.Context, system, prompt string) (string, error) {
+	reqBody, err := json.Marshal(map[string]any{
+		"model":      c.model,
+		"max_tokens": 4096,
+		"system":     system,
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("llm: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/v1/messages", bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("llm: build request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("llm: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Cap the response body to prevent unbounded memory use if the server
+	// sends an unexpectedly large or malformed response.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return "", fmt.Errorf("llm: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Do not include the response body for authentication failures: the
+		// body may echo sensitive request details. For other error codes the
+		// truncated body is useful diagnostic text.
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return "", fmt.Errorf("llm: API authentication error %d (check MESHANT_LLM_API_KEY)", resp.StatusCode)
+		}
+		return "", fmt.Errorf("llm: API error %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	// Parse the Messages API response envelope.
+	var result struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("llm: parse API response: %w", err)
+	}
+	for _, block := range result.Content {
+		if block.Type == "text" {
+			return block.Text, nil
+		}
+	}
+	return "", nil
+}
+
+// truncate returns s truncated to at most n bytes, with "..." appended if
+// truncation occurred. Used to limit error message lengths.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return strings.TrimSpace(s[:n]) + "..."
+}

--- a/meshant/llm/client_test.go
+++ b/meshant/llm/client_test.go
@@ -1,0 +1,92 @@
+package llm_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/llm"
+)
+
+// clearLLMEnv unsets both API key env vars and returns a restore function.
+func clearLLMEnv(t *testing.T) func() {
+	t.Helper()
+	prev1 := os.Getenv("MESHANT_LLM_API_KEY")
+	prev2 := os.Getenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("MESHANT_LLM_API_KEY")
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	return func() {
+		os.Setenv("MESHANT_LLM_API_KEY", prev1)
+		os.Setenv("ANTHROPIC_API_KEY", prev2)
+	}
+}
+
+func TestNewAnthropicClient_MissingKey(t *testing.T) {
+	restore := clearLLMEnv(t)
+	defer restore()
+
+	_, err := llm.NewAnthropicClient("claude-sonnet-4-6")
+	if err == nil {
+		t.Fatal("want error for missing API key, got nil")
+	}
+	if !strings.Contains(err.Error(), "MESHANT_LLM_API_KEY") {
+		t.Errorf("error should name MESHANT_LLM_API_KEY, got: %v", err)
+	}
+}
+
+func TestNewAnthropicClient_EmptyKey(t *testing.T) {
+	restore := clearLLMEnv(t)
+	defer restore()
+	os.Setenv("MESHANT_LLM_API_KEY", "")
+
+	_, err := llm.NewAnthropicClient("claude-sonnet-4-6")
+	if err == nil {
+		t.Fatal("want error for empty API key, got nil")
+	}
+	if !strings.Contains(err.Error(), "MESHANT_LLM_API_KEY") {
+		t.Errorf("error should name MESHANT_LLM_API_KEY, got: %v", err)
+	}
+}
+
+func TestNewAnthropicClient_PrimaryKey(t *testing.T) {
+	restore := clearLLMEnv(t)
+	defer restore()
+	os.Setenv("MESHANT_LLM_API_KEY", "test-key-primary")
+
+	c, err := llm.NewAnthropicClient("claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("want no error with primary key, got: %v", err)
+	}
+	if c == nil {
+		t.Fatal("want non-nil client")
+	}
+}
+
+func TestNewAnthropicClient_FallbackKey(t *testing.T) {
+	restore := clearLLMEnv(t)
+	defer restore()
+	// Primary key absent; fallback should be used.
+	os.Setenv("ANTHROPIC_API_KEY", "test-key-fallback")
+
+	c, err := llm.NewAnthropicClient("claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("want no error with fallback key, got: %v", err)
+	}
+	if c == nil {
+		t.Fatal("want non-nil client")
+	}
+}
+
+func TestNewAnthropicClient_PrimaryTakesPrecedence(t *testing.T) {
+	restore := clearLLMEnv(t)
+	defer restore()
+	os.Setenv("MESHANT_LLM_API_KEY", "primary-key")
+	os.Setenv("ANTHROPIC_API_KEY", "fallback-key")
+
+	// Both set — should succeed (primary wins, but we can only observe
+	// that construction succeeds, not which key was used).
+	_, err := llm.NewAnthropicClient("claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("want no error when both keys set, got: %v", err)
+	}
+}

--- a/meshant/llm/extract.go
+++ b/meshant/llm/extract.go
@@ -1,0 +1,234 @@
+// extract.go implements RunExtraction — the core LLM extraction operation.
+//
+// RunExtraction calls an LLM to produce candidate TraceDraft records from a
+// source document. It always returns a non-nil SessionRecord, enforces all
+// F.1 provenance conventions (D2–D7), and validates IntentionallyBlank entries
+// against the known content field list.
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/automatedtomato/mesh-ant/meshant/loader"
+	"github.com/automatedtomato/mesh-ant/meshant/schema"
+)
+
+// RunExtraction calls the LLM to produce candidate TraceDraft records from
+// a source document. It always returns a non-nil SessionRecord, even on error.
+//
+// Data flow:
+//  1. Read source document from opts.InputPath (capped at maxSourceBytes)
+//  2. Load prompt template from opts.PromptTemplatePath
+//  3. Call client.Complete(ctx, systemInstructions, sourceDoc)
+//  4. Parse LLM response as JSON array of partial TraceDraft
+//  5. For each parsed draft: assign UUID, set ExtractedBy, ExtractionStage,
+//     SessionRef, UncertaintyNote (framework-appended), SourceDocRef
+//  6. Validate IntentionallyBlank field names against knownContentFields
+//  7. Validate each draft via schema.TraceDraft.Validate()
+//  8. Return drafts + SessionRecord
+//
+// The SessionRecord is returned on every code path. On error, DraftCount is 0
+// and ErrorNote carries the reason. The caller writes the SessionRecord to disk.
+func RunExtraction(ctx context.Context, client LLMClient, opts ExtractionOptions) ([]schema.TraceDraft, SessionRecord, error) {
+	sessionID, err := loader.NewUUID()
+	if err != nil {
+		return nil, SessionRecord{}, fmt.Errorf("llm: generate session ID: %w", err)
+	}
+
+	now := time.Now().UTC()
+
+	// Build a partial SessionRecord early so we can populate ErrorNote and
+	// return it on any error path below.
+	rec := SessionRecord{
+		ID:        sessionID,
+		Command:   "extract",
+		InputPath: opts.InputPath,
+		OutputPath: opts.OutputPath,
+		Timestamp: now,
+	}
+
+	// Step 1: Read source document.
+	sourceDoc, err := readSourceDoc(opts.InputPath)
+	if err != nil {
+		rec.ErrorNote = err.Error()
+		return nil, rec, err
+	}
+
+	// Step 2: Load prompt template.
+	systemInstructions, err := LoadPromptTemplate(opts.PromptTemplatePath)
+	if err != nil {
+		rec.ErrorNote = err.Error()
+		return nil, rec, err
+	}
+
+	// Populate ExtractionConditions now that we have all the pieces.
+	rec.Conditions = ExtractionConditions{
+		ModelID:            opts.ModelID,
+		PromptTemplate:     opts.PromptTemplatePath,
+		CriterionRef:       opts.CriterionRef,
+		SystemInstructions: systemInstructions,
+		SourceDocRef:       opts.SourceDocRef,
+		Timestamp:          now,
+	}
+
+	// Step 3: Call the LLM.
+	rawResponse, err := client.Complete(ctx, systemInstructions, sourceDoc)
+	if err != nil {
+		rec.ErrorNote = fmt.Sprintf("LLM client error: %v", err)
+		return nil, rec, fmt.Errorf("llm: complete: %w", err)
+	}
+
+	// Step 4: Detect refusals before attempting JSON parse.
+	if isRefusal(rawResponse) {
+		refErr := &ErrLLMRefusal{RefusalText: rawResponse}
+		rec.ErrorNote = refErr.Error()
+		return nil, rec, refErr
+	}
+
+	// Step 5: Parse response as JSON array of TraceDraft.
+	drafts, err := parseResponse(rawResponse)
+	if err != nil {
+		malformed := &ErrMalformedOutput{RawResponse: rawResponse, ParseErr: err}
+		rec.ErrorNote = malformed.Error()
+		return nil, rec, malformed
+	}
+
+	// Step 6: Post-process each draft — assign provenance, validate blanks.
+	processed := make([]schema.TraceDraft, 0, len(drafts))
+	for i := range drafts {
+		d := &drafts[i]
+
+		// Validate IntentionallyBlank field names (D7).
+		if err := validateIntentionallyBlank(d.IntentionallyBlank); err != nil {
+			rec.ErrorNote = fmt.Sprintf("draft %d: %v", i, err)
+			return nil, rec, fmt.Errorf("llm: draft %d: %w", i, err)
+		}
+
+		// Assign a fresh UUID.
+		id, err := loader.NewUUID()
+		if err != nil {
+			rec.ErrorNote = fmt.Sprintf("draft %d: generate UUID: %v", i, err)
+			return nil, rec, fmt.Errorf("llm: draft %d: generate UUID: %w", i, err)
+		}
+		d.ID = id
+		d.Timestamp = now
+
+		// Set framework-assigned provenance (D2, D4, F.0).
+		d.ExtractedBy = opts.ModelID
+		d.ExtractionStage = "weak-draft"
+		d.SessionRef = sessionID
+		d.SourceDocRef = opts.SourceDocRef
+
+		// Append framework uncertainty note (D3). Always appended; never
+		// replaced. If the LLM set a note, preserve it and append.
+		if d.UncertaintyNote != "" {
+			d.UncertaintyNote = d.UncertaintyNote + " " + frameworkUncertaintyNote
+		} else {
+			d.UncertaintyNote = frameworkUncertaintyNote
+		}
+
+		// Validate the draft — only SourceSpan is required.
+		if err := d.Validate(); err != nil {
+			rec.ErrorNote = fmt.Sprintf("draft %d validation: %v", i, err)
+			return nil, rec, fmt.Errorf("llm: draft %d: %w", i, err)
+		}
+
+		processed = append(processed, *d)
+	}
+
+	// Step 7: Populate remaining SessionRecord fields.
+	rec.DraftCount = len(processed)
+	rec.DraftIDs = make([]string, len(processed))
+	for i, d := range processed {
+		rec.DraftIDs[i] = d.ID
+	}
+
+	return processed, rec, nil
+}
+
+// readSourceDoc reads the source document at path, enforcing the maxSourceBytes
+// cap. Returns a clear error if the file is missing or too large.
+func readSourceDoc(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("llm: open source doc %q: %w", path, err)
+	}
+	defer f.Close()
+
+	// Read one byte beyond the cap to detect oversized files.
+	limited := io.LimitReader(f, int64(maxSourceBytes)+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("llm: read source doc %q: %w", path, err)
+	}
+	if len(data) > maxSourceBytes {
+		return "", fmt.Errorf("llm: source doc %q exceeds %d bytes", path, maxSourceBytes)
+	}
+	return string(data), nil
+}
+
+// isRefusal reports whether the LLM response looks like an explicit refusal.
+// This is a conservative heuristic: only clear refusal prefixes are matched.
+// False negatives (undetected refusals that parse as non-JSON) are caught
+// by the malformed-output path.
+func isRefusal(response string) bool {
+	trimmed := strings.TrimSpace(response)
+	if trimmed == "" {
+		return false // empty response → malformed, not refusal
+	}
+	prefixes := []string{
+		"I cannot",
+		"I'm sorry",
+		"I am sorry",
+		"I apologize",
+		"I'm unable",
+		"I am unable",
+	}
+	lower := strings.ToLower(trimmed)
+	for _, p := range prefixes {
+		if strings.HasPrefix(lower, strings.ToLower(p)) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseResponse parses the LLM's text output as a JSON array of TraceDraft.
+// It trims whitespace and attempts to locate the JSON array start marker
+// before decoding, tolerating minor LLM preamble.
+func parseResponse(raw string) ([]schema.TraceDraft, error) {
+	s := strings.TrimSpace(raw)
+
+	// Find the start of the JSON array; some LLMs prefix with a sentence.
+	if idx := strings.Index(s, "["); idx >= 0 {
+		s = s[idx:]
+	}
+	// Trim any trailing content after the last ']'.
+	if idx := strings.LastIndex(s, "]"); idx >= 0 {
+		s = s[:idx+1]
+	}
+
+	var drafts []schema.TraceDraft
+	if err := json.Unmarshal([]byte(s), &drafts); err != nil {
+		return nil, err
+	}
+	return drafts, nil
+}
+
+// validateIntentionallyBlank returns an error if any name in the slice is not
+// a known content field. Provenance fields cannot be declared intentionally
+// blank by the LLM (D7 in docs/decisions/llm-as-mediator-v1.md).
+func validateIntentionallyBlank(fields []string) error {
+	for _, name := range fields {
+		if !knownContentFields[name] {
+			return fmt.Errorf("intentionally_blank: %q is not a valid content field name", name)
+		}
+	}
+	return nil
+}

--- a/meshant/llm/extract_test.go
+++ b/meshant/llm/extract_test.go
@@ -1,0 +1,521 @@
+package llm_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/llm"
+)
+
+// mockClient is a test double for LLMClient. It returns a canned response or
+// error on each call to Complete, advancing through responses in order.
+type mockClient struct {
+	responses []string
+	errs      []error
+	calls     int
+}
+
+func (m *mockClient) Complete(_ context.Context, _, _ string) (string, error) {
+	i := m.calls
+	m.calls++
+	if i < len(m.errs) && m.errs[i] != nil {
+		return "", m.errs[i]
+	}
+	if i < len(m.responses) {
+		return m.responses[i], nil
+	}
+	return "[]", nil
+}
+
+// newMockClient returns a mock that returns the given response on every call.
+func newMockClient(response string) *mockClient {
+	return &mockClient{responses: []string{response}}
+}
+
+// newErrClient returns a mock that returns the given error on every call.
+func newErrClient(err error) *mockClient {
+	return &mockClient{errs: []error{err}}
+}
+
+// writeSourceDoc writes content to a temp file and returns its path.
+func writeSourceDoc(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "source.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write source doc: %v", err)
+	}
+	return path
+}
+
+// writePromptTemplate writes a minimal prompt template and returns its path.
+func writePromptTemplate(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(path, []byte("Extract trace drafts."), 0o644); err != nil {
+		t.Fatalf("write prompt template: %v", err)
+	}
+	return path
+}
+
+// baseOpts returns a valid ExtractionOptions pointing at real temp files.
+func baseOpts(t *testing.T, sourcePath, promptPath string) llm.ExtractionOptions {
+	t.Helper()
+	return llm.ExtractionOptions{
+		ModelID:            "claude-sonnet-4-6",
+		InputPath:          sourcePath,
+		PromptTemplatePath: promptPath,
+		SourceDocRef:       "test-doc",
+	}
+}
+
+const validDraftsJSON = `[
+  {
+    "source_span": "The system failed at 14:00.",
+    "what_changed": "system failure observed",
+    "observer": "ops-engineer"
+  },
+  {
+    "source_span": "Recovery completed by 14:45.",
+    "what_changed": "recovery completed"
+  }
+]`
+
+// --- Tests ---
+
+func TestRunExtraction_HappyPath(t *testing.T) {
+	src := writeSourceDoc(t, "The system failed at 14:00. Recovery completed by 14:45.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient(validDraftsJSON)
+
+	drafts, rec, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err != nil {
+		t.Fatalf("want no error, got: %v", err)
+	}
+	if len(drafts) != 2 {
+		t.Fatalf("want 2 drafts, got %d", len(drafts))
+	}
+
+	// SessionRecord invariants.
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty")
+	}
+	if rec.Command != "extract" {
+		t.Errorf("SessionRecord.Command: want %q, got %q", "extract", rec.Command)
+	}
+	if rec.DraftCount != 2 {
+		t.Errorf("SessionRecord.DraftCount: want 2, got %d", rec.DraftCount)
+	}
+	if rec.ErrorNote != "" {
+		t.Errorf("SessionRecord.ErrorNote: want empty on success, got %q", rec.ErrorNote)
+	}
+	if len(rec.DraftIDs) != 2 {
+		t.Errorf("SessionRecord.DraftIDs: want 2, got %d", len(rec.DraftIDs))
+	}
+
+	// Per-draft provenance invariants.
+	for i, d := range drafts {
+		if d.ID == "" {
+			t.Errorf("draft[%d].ID: must be non-empty", i)
+		}
+		if d.ExtractedBy != "claude-sonnet-4-6" {
+			t.Errorf("draft[%d].ExtractedBy: want %q, got %q", i, "claude-sonnet-4-6", d.ExtractedBy)
+		}
+		if d.ExtractionStage != "weak-draft" {
+			t.Errorf("draft[%d].ExtractionStage: want %q, got %q", i, "weak-draft", d.ExtractionStage)
+		}
+		if d.SessionRef != rec.ID {
+			t.Errorf("draft[%d].SessionRef: want %q, got %q", i, rec.ID, d.SessionRef)
+		}
+		if !strings.Contains(d.UncertaintyNote, "LLM-produced candidate; unverified by human review") {
+			t.Errorf("draft[%d].UncertaintyNote missing framework suffix: %q", i, d.UncertaintyNote)
+		}
+		if d.SourceDocRef != "test-doc" {
+			t.Errorf("draft[%d].SourceDocRef: want %q, got %q", i, "test-doc", d.SourceDocRef)
+		}
+		if err := d.Validate(); err != nil {
+			t.Errorf("draft[%d].Validate(): %v", i, err)
+		}
+		// Draft IDs must appear in SessionRecord.DraftIDs.
+		found := false
+		for _, id := range rec.DraftIDs {
+			if id == d.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("draft[%d].ID %q not found in SessionRecord.DraftIDs", i, d.ID)
+		}
+	}
+}
+
+func TestRunExtraction_EmptyResponse(t *testing.T) {
+	src := writeSourceDoc(t, "Some source text.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient("[]")
+
+	drafts, rec, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err != nil {
+		t.Fatalf("want no error for empty response, got: %v", err)
+	}
+	if len(drafts) != 0 {
+		t.Errorf("want 0 drafts, got %d", len(drafts))
+	}
+	if rec.DraftCount != 0 {
+		t.Errorf("SessionRecord.DraftCount: want 0, got %d", rec.DraftCount)
+	}
+	// SessionRecord must still be non-zero and valid.
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty even for empty response")
+	}
+}
+
+func TestRunExtraction_MalformedResponse(t *testing.T) {
+	src := writeSourceDoc(t, "Some source text.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient("not json at all {{")
+
+	_, rec, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err == nil {
+		t.Fatal("want error for malformed response, got nil")
+	}
+
+	var malformed *llm.ErrMalformedOutput
+	if !errors.As(err, &malformed) {
+		t.Errorf("want ErrMalformedOutput, got %T: %v", err, err)
+	}
+	if malformed != nil && !strings.Contains(malformed.RawResponse, "not json") {
+		t.Errorf("ErrMalformedOutput.RawResponse should contain original text, got: %q", malformed.RawResponse)
+	}
+	// SessionRecord must still be returned with ErrorNote.
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty even on error")
+	}
+	if rec.ErrorNote == "" {
+		t.Error("SessionRecord.ErrorNote must be set on malformed output error")
+	}
+}
+
+func TestRunExtraction_Refusal(t *testing.T) {
+	src := writeSourceDoc(t, "Some source text.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient("I cannot assist with this request.")
+
+	_, rec, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err == nil {
+		t.Fatal("want error for refusal, got nil")
+	}
+
+	var refusal *llm.ErrLLMRefusal
+	if !errors.As(err, &refusal) {
+		t.Errorf("want ErrLLMRefusal, got %T: %v", err, err)
+	}
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty even on refusal")
+	}
+	if rec.ErrorNote == "" {
+		t.Error("SessionRecord.ErrorNote must be set on refusal")
+	}
+}
+
+func TestRunExtraction_UncertaintyNote_FrameworkAppended(t *testing.T) {
+	// LLM returns a draft with its own uncertainty note already set.
+	const draftsWithNote = `[
+  {
+    "source_span": "The deployment failed.",
+    "uncertainty_note": "attribution unclear from this span"
+  }
+]`
+	src := writeSourceDoc(t, "The deployment failed.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient(draftsWithNote)
+
+	drafts, _, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err != nil {
+		t.Fatalf("want no error, got: %v", err)
+	}
+	if len(drafts) != 1 {
+		t.Fatalf("want 1 draft, got %d", len(drafts))
+	}
+
+	note := drafts[0].UncertaintyNote
+	// Both the LLM's note and the framework suffix must be present.
+	if !strings.Contains(note, "attribution unclear from this span") {
+		t.Errorf("LLM uncertainty note must be preserved: %q", note)
+	}
+	if !strings.Contains(note, "LLM-produced candidate; unverified by human review") {
+		t.Errorf("framework uncertainty suffix must be appended: %q", note)
+	}
+}
+
+func TestRunExtraction_UncertaintyNote_EmptyLLMNote(t *testing.T) {
+	// LLM returns draft with no uncertainty note — framework must still append.
+	const draftsNoNote = `[{"source_span": "The cache expired."}]`
+	src := writeSourceDoc(t, "The cache expired.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient(draftsNoNote)
+
+	drafts, _, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err != nil {
+		t.Fatalf("want no error, got: %v", err)
+	}
+	if len(drafts) == 0 {
+		t.Fatal("want at least 1 draft")
+	}
+	if !strings.Contains(drafts[0].UncertaintyNote, "LLM-produced candidate; unverified by human review") {
+		t.Errorf("framework suffix must be set even when LLM note is empty: %q", drafts[0].UncertaintyNote)
+	}
+}
+
+func TestRunExtraction_SessionRef_OnEveryDraft(t *testing.T) {
+	const threeDrafts = `[
+  {"source_span": "span one"},
+  {"source_span": "span two"},
+  {"source_span": "span three"}
+]`
+	src := writeSourceDoc(t, "span one\nspan two\nspan three")
+	prompt := writePromptTemplate(t)
+	client := newMockClient(threeDrafts)
+
+	drafts, rec, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err != nil {
+		t.Fatalf("want no error, got: %v", err)
+	}
+	if len(drafts) != 3 {
+		t.Fatalf("want 3 drafts, got %d", len(drafts))
+	}
+	for i, d := range drafts {
+		if d.SessionRef == "" {
+			t.Errorf("draft[%d].SessionRef must be non-empty", i)
+		}
+		if d.SessionRef != rec.ID {
+			t.Errorf("draft[%d].SessionRef %q != SessionRecord.ID %q", i, d.SessionRef, rec.ID)
+		}
+	}
+}
+
+func TestRunExtraction_IntentionallyBlank_Valid(t *testing.T) {
+	const draftsWithBlank = `[
+  {
+    "source_span": "The service degraded.",
+    "intentionally_blank": ["source", "tags"]
+  }
+]`
+	src := writeSourceDoc(t, "The service degraded.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient(draftsWithBlank)
+
+	drafts, _, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err != nil {
+		t.Fatalf("want no error for valid intentionally_blank, got: %v", err)
+	}
+	if len(drafts) != 1 {
+		t.Fatalf("want 1 draft, got %d", len(drafts))
+	}
+	blank := drafts[0].IntentionallyBlank
+	if len(blank) != 2 || blank[0] != "source" || blank[1] != "tags" {
+		t.Errorf("IntentionallyBlank not preserved: %v", blank)
+	}
+}
+
+func TestRunExtraction_IntentionallyBlank_Invalid(t *testing.T) {
+	// "extracted_by" is a provenance field — not valid in intentionally_blank.
+	const draftsWithBadBlank = `[
+  {
+    "source_span": "The service degraded.",
+    "intentionally_blank": ["extracted_by"]
+  }
+]`
+	src := writeSourceDoc(t, "The service degraded.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient(draftsWithBadBlank)
+
+	_, _, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err == nil {
+		t.Fatal("want error for invalid intentionally_blank field name, got nil")
+	}
+}
+
+func TestRunExtraction_SourceDocTooLarge(t *testing.T) {
+	// Write a file larger than maxSourceBytes (1 MiB).
+	dir := t.TempDir()
+	largePath := filepath.Join(dir, "large.md")
+	large := make([]byte, 1*1024*1024+1)
+	for i := range large {
+		large[i] = 'x'
+	}
+	if err := os.WriteFile(largePath, large, 0o644); err != nil {
+		t.Fatalf("write large file: %v", err)
+	}
+	prompt := writePromptTemplate(t)
+	client := newMockClient("[]")
+
+	opts := llm.ExtractionOptions{
+		ModelID:            "claude-sonnet-4-6",
+		InputPath:          largePath,
+		PromptTemplatePath: prompt,
+	}
+	_, _, err := llm.RunExtraction(context.Background(), client, opts)
+	if err == nil {
+		t.Fatal("want error for oversized source doc, got nil")
+	}
+}
+
+func TestRunExtraction_ClientError(t *testing.T) {
+	src := writeSourceDoc(t, "Some text.")
+	prompt := writePromptTemplate(t)
+	clientErr := errors.New("network timeout")
+	client := newErrClient(clientErr)
+
+	_, rec, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err == nil {
+		t.Fatal("want error when client fails, got nil")
+	}
+	if rec.ID == "" {
+		t.Error("SessionRecord must be returned even on client error")
+	}
+	if rec.ErrorNote == "" {
+		t.Error("SessionRecord.ErrorNote must be set on client error")
+	}
+}
+
+func TestRunExtraction_SessionRecord_AlwaysReturned(t *testing.T) {
+	// Covers multiple error paths to verify SessionRecord is never zero-valued.
+	cases := []struct {
+		name     string
+		response string
+		wantErr  bool
+	}{
+		{"success", validDraftsJSON, false},
+		{"empty", "[]", false},
+		{"malformed", "{bad json", true},
+		{"refusal", "I'm sorry, I cannot help.", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := writeSourceDoc(t, "source text")
+			prompt := writePromptTemplate(t)
+			client := newMockClient(tc.response)
+
+			_, rec, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+			if tc.wantErr && err == nil {
+				t.Errorf("want error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("want no error, got: %v", err)
+			}
+			// SessionRecord must always have a non-empty ID.
+			if rec.ID == "" {
+				t.Errorf("SessionRecord.ID must be non-empty (case: %s)", tc.name)
+			}
+			if rec.Command != "extract" {
+				t.Errorf("SessionRecord.Command: want %q, got %q", "extract", rec.Command)
+			}
+		})
+	}
+}
+
+func TestRunExtraction_MissingSourceDoc(t *testing.T) {
+	prompt := writePromptTemplate(t)
+	client := newMockClient("[]")
+
+	opts := llm.ExtractionOptions{
+		ModelID:            "claude-sonnet-4-6",
+		InputPath:          "/nonexistent/source.md",
+		PromptTemplatePath: prompt,
+	}
+	_, _, err := llm.RunExtraction(context.Background(), client, opts)
+	if err == nil {
+		t.Fatal("want error for missing source doc, got nil")
+	}
+}
+
+func TestRunExtraction_MissingPromptTemplate(t *testing.T) {
+	src := writeSourceDoc(t, "Some source text.")
+	client := newMockClient("[]")
+
+	opts := llm.ExtractionOptions{
+		ModelID:            "claude-sonnet-4-6",
+		InputPath:          src,
+		PromptTemplatePath: "/nonexistent/prompt.md",
+	}
+	_, rec, err := llm.RunExtraction(context.Background(), client, opts)
+	if err == nil {
+		t.Fatal("want error for missing prompt template, got nil")
+	}
+	// SessionRecord must still be returned with ErrorNote.
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty even when prompt template is missing")
+	}
+	if rec.ErrorNote == "" {
+		t.Error("SessionRecord.ErrorNote must be set when prompt template is missing")
+	}
+}
+
+func TestRunExtraction_EmptyStringResponse(t *testing.T) {
+	// An empty-string LLM response is not a refusal — it is malformed output.
+	// The isRefusal function explicitly returns false for the empty-string case
+	// ("empty response → malformed, not refusal").
+	src := writeSourceDoc(t, "Some source text.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient("")
+
+	_, _, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err == nil {
+		t.Fatal("want error for empty-string response, got nil")
+	}
+	var malformed *llm.ErrMalformedOutput
+	if !errors.As(err, &malformed) {
+		t.Errorf("empty-string response must produce ErrMalformedOutput, got %T: %v", err, err)
+	}
+}
+
+func TestRunExtraction_PreambleBeforeJSON(t *testing.T) {
+	// Some LLMs prefix their JSON output with a sentence. parseResponse strips
+	// the preamble by finding the first '[' and last ']'.
+	const responseWithPreamble = `Here are the candidate trace drafts:
+[
+  {"source_span": "The router went offline at 02:00.", "what_changed": "router offline"}
+]`
+	src := writeSourceDoc(t, "The router went offline at 02:00.")
+	prompt := writePromptTemplate(t)
+	client := newMockClient(responseWithPreamble)
+
+	drafts, _, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err != nil {
+		t.Fatalf("want no error for response with preamble, got: %v", err)
+	}
+	if len(drafts) != 1 {
+		t.Fatalf("want 1 draft parsed despite preamble, got %d", len(drafts))
+	}
+	if drafts[0].SourceSpan != "The router went offline at 02:00." {
+		t.Errorf("source_span not preserved: %q", drafts[0].SourceSpan)
+	}
+}
+
+func TestRunExtraction_DraftValidationFailure(t *testing.T) {
+	// A draft with no source_span fails schema validation. RunExtraction must
+	// return an error and set SessionRecord.ErrorNote.
+	const draftWithoutSourceSpan = `[{"what_changed": "something happened"}]`
+	src := writeSourceDoc(t, "something happened")
+	prompt := writePromptTemplate(t)
+	client := newMockClient(draftWithoutSourceSpan)
+
+	_, rec, err := llm.RunExtraction(context.Background(), client, baseOpts(t, src, prompt))
+	if err == nil {
+		t.Fatal("want error when draft has no source_span, got nil")
+	}
+	if rec.ID == "" {
+		t.Error("SessionRecord.ID must be non-empty even on draft validation failure")
+	}
+	if rec.ErrorNote == "" {
+		t.Error("SessionRecord.ErrorNote must be set on draft validation failure")
+	}
+}

--- a/meshant/llm/prompt.go
+++ b/meshant/llm/prompt.go
@@ -1,0 +1,33 @@
+// prompt.go provides LoadPromptTemplate for reading extraction prompt files.
+package llm
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// LoadPromptTemplate reads a prompt template file from disk and returns its
+// contents as a string. The file is read up to maxSourceBytes; files larger
+// than that are rejected with a clear error.
+//
+// An empty file returns an empty string without error — empty system
+// instructions are valid (the caller may supply instructions another way).
+// A missing file returns a clear error naming the path.
+func LoadPromptTemplate(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("llm: open prompt template %q: %w", path, err)
+	}
+	defer f.Close()
+
+	limited := io.LimitReader(f, maxSourceBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("llm: read prompt template %q: %w", path, err)
+	}
+	if len(data) > maxSourceBytes {
+		return "", fmt.Errorf("llm: prompt template %q exceeds %d bytes", path, maxSourceBytes)
+	}
+	return string(data), nil
+}

--- a/meshant/llm/prompt_test.go
+++ b/meshant/llm/prompt_test.go
@@ -1,0 +1,67 @@
+package llm_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/llm"
+)
+
+func TestLoadPromptTemplate_Valid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.md")
+	content := "# Extraction Pass\n\nYou are a mediating instrument."
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	got, err := llm.LoadPromptTemplate(path)
+	if err != nil {
+		t.Fatalf("want no error, got: %v", err)
+	}
+	if got != content {
+		t.Errorf("want %q, got %q", content, got)
+	}
+}
+
+func TestLoadPromptTemplate_Missing(t *testing.T) {
+	_, err := llm.LoadPromptTemplate("/nonexistent/path/prompt.md")
+	if err == nil {
+		t.Fatal("want error for missing file, got nil")
+	}
+}
+
+func TestLoadPromptTemplate_TooLarge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "large.md")
+	// Write one byte beyond the 1 MiB cap.
+	large := make([]byte, 1*1024*1024+1)
+	for i := range large {
+		large[i] = 'x'
+	}
+	if err := os.WriteFile(path, large, 0o644); err != nil {
+		t.Fatalf("write large file: %v", err)
+	}
+
+	_, err := llm.LoadPromptTemplate(path)
+	if err == nil {
+		t.Fatal("want error for oversized prompt template, got nil")
+	}
+}
+
+func TestLoadPromptTemplate_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.md")
+	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	got, err := llm.LoadPromptTemplate(path)
+	if err != nil {
+		t.Fatalf("empty file should not error, got: %v", err)
+	}
+	if got != "" {
+		t.Errorf("want empty string, got %q", got)
+	}
+}

--- a/meshant/llm/types.go
+++ b/meshant/llm/types.go
@@ -1,0 +1,108 @@
+// types.go defines the types shared across the llm package.
+//
+// The central concern is provenance: every LLM interaction produces a
+// SessionRecord that records the conditions under which drafts were made.
+// ExtractionConditions deliberately excludes the API key — conditions are
+// written to disk and must never carry secrets.
+package llm
+
+import (
+	"fmt"
+	"time"
+)
+
+// ExtractionConditions records the apparatus configuration for one LLM
+// session. It is embedded in SessionRecord and written to disk.
+//
+// The API key is intentionally absent. Two runs with different keys but the
+// same conditions are analytically indistinguishable — the key is an
+// operational detail, not an analytical position.
+type ExtractionConditions struct {
+	ModelID            string    `json:"model_id"`
+	PromptTemplate     string    `json:"prompt_template"`
+	CriterionRef       string    `json:"criterion_ref,omitempty"`
+	SystemInstructions string    `json:"system_instructions"`
+	SourceDocRef       string    `json:"source_doc_ref"`
+	Timestamp          time.Time `json:"timestamp"`
+}
+
+// DraftDisposition records the fate of a single draft within a session.
+// Used by assist and critique sessions; empty in extract sessions (all
+// drafts from extract are implicitly "accepted" into the output).
+type DraftDisposition struct {
+	DraftID string `json:"draft_id"`
+	Action  string `json:"action"` // "accepted", "edited", "skipped"
+}
+
+// SessionRecord is the mandatory companion to every LLM interaction. It is
+// returned on every code path — success, error, and partial completion.
+//
+// SessionRecord.ID is the SessionRef stamped on every draft produced in
+// the session, linking each draft back to the conditions under which it
+// was produced (FM4 from plan_thread_f.md).
+type SessionRecord struct {
+	ID           string               `json:"id"`
+	Command      string               `json:"command"` // "extract", "assist", "critique"
+	Conditions   ExtractionConditions `json:"conditions"`
+	DraftIDs     []string             `json:"draft_ids"`
+	Dispositions []DraftDisposition   `json:"dispositions,omitempty"`
+	InputPath    string               `json:"input_path"`
+	OutputPath   string               `json:"output_path"`
+	DraftCount   int                  `json:"draft_count"`
+	ErrorNote    string               `json:"error_note,omitempty"`
+	Timestamp    time.Time            `json:"timestamp"`
+}
+
+// ExtractionOptions configures a single RunExtraction call.
+type ExtractionOptions struct {
+	ModelID            string
+	InputPath          string
+	PromptTemplatePath string
+	CriterionRef       string
+	SourceDocRef       string
+	OutputPath         string
+	SessionOutputPath  string
+}
+
+// ErrLLMRefusal indicates the LLM explicitly declined to produce output.
+// The RefusalText carries whatever the LLM returned for debugging.
+type ErrLLMRefusal struct {
+	RefusalText string
+}
+
+func (e *ErrLLMRefusal) Error() string {
+	return fmt.Sprintf("llm: refusal: %s", e.RefusalText)
+}
+
+// ErrMalformedOutput indicates the LLM returned text that does not parse
+// as valid TraceDraft JSON. RawResponse carries the unparsed text.
+type ErrMalformedOutput struct {
+	RawResponse string
+	ParseErr    error
+}
+
+func (e *ErrMalformedOutput) Error() string {
+	return fmt.Sprintf("llm: malformed output: %v", e.ParseErr)
+}
+
+// frameworkUncertaintyNote is always appended to UncertaintyNote on
+// LLM-produced drafts (Decision D3 in docs/decisions/llm-as-mediator-v1.md).
+// The framework never delegates this signal to the LLM.
+const frameworkUncertaintyNote = "LLM-produced candidate; unverified by human review"
+
+// maxSourceBytes caps source document size at 1 MiB. Documents larger than
+// this are rejected before any LLM call to prevent unexpected token costs.
+const maxSourceBytes = 1 * 1024 * 1024
+
+// knownContentFields lists the TraceDraft field names valid for use in
+// IntentionallyBlank (Decision D7). Only content fields are valid; provenance
+// fields like extracted_by and session_ref are framework-assigned and cannot
+// be declared blank by the LLM.
+var knownContentFields = map[string]bool{
+	"what_changed": true,
+	"source":       true,
+	"target":       true,
+	"mediation":    true,
+	"observer":     true,
+	"tags":         true,
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -700,7 +700,7 @@ Parent issue: #115
 - [x] **Phase 0 (#116) — CLI file split** — `main.go` 2003 → 259 lines; 15 `cmd_*.go` files; PR #123 merged to develop
 - [x] **F.0 (#114) — `SessionRef` on TraceDraft** — `SessionRef string` on `TraceDraft`; `WithSessionRef` in `DraftSummary`; preserved by `deriveAccepted`/`deriveEdited`; not transferred by `Promote()`; 7 new tests; PR #124 merged to develop
 - [x] **F.1 (#117) — LLM mediator convention** — `docs/decisions/llm-as-mediator-v1.md` (7 decisions + 3 ANT tensions); `"critiqued"` added to `ExtractionStage` doc comment; `data/prompts/extraction_pass.md`; `critique_pass.md` updated to align with Decision 5; PR #125 merged to develop
-- [ ] **F.2 (#118) — `meshant extract`** — new `meshant/llm` package; `LLMClient` interface; `ExtractionConditions`; `SessionRecord`; `RunExtraction`; `cmdExtract`
+- [x] **F.2 (#118) — `meshant extract`** — new `meshant/llm` package; `LLMClient` interface; `ExtractionConditions`; `SessionRecord`; `RunExtraction`; `cmdExtract`; HTTP timeout + response size cap + auth error scrubbing; 27 tests (18 unit + 9 CLI); PR #126 merged to develop
 - [ ] **F.3 (#119) — `meshant assist`** — interactive authoring companion; LLM suggests per span; user confirms/edits/skips; skipped drafts preserved; `RunAssistSession`; per-draft dispositions in SessionRecord
 - [ ] **F.4 (#120) — `meshant critique`** — `RunCritique`; `"critiqued"` stage; `filterReviewable` updated; `cmdCritique`
 - [ ] **F.5 (#121) — Real-world LLM-assisted extraction example** — `data/examples/llm_assisted_extraction/`; full pipeline documented


### PR DESCRIPTION
## Summary

- New `meshant/llm` package: `LLMClient` interface, `AnthropicClient` (stdlib net/http, zero external deps), `RunExtraction`, `LoadPromptTemplate`, shared types (`SessionRecord`, `ExtractionConditions`, `ExtractionOptions`, error types)
- New `meshant extract` subcommand: calls an LLM to produce `TraceDraft` records from a source document; writes TraceDraft JSON array + `SessionRecord` JSON on every code path (success and error)
- Enforces all F.1 conventions (D1–D7): mediator framing, `ExtractedBy` = model ID string, `frameworkUncertaintyNote = "LLM-produced candidate; unverified by human review"` always appended, `ExtractionStage = "weak-draft"`, `SessionRef` stamped on every draft, `IntentionallyBlank` validated against content-field allowlist

## Security

- `AnthropicClient` uses a private `http.Client` with 180 s timeout (never `http.DefaultClient`)
- Response body capped at 8 MiB via `io.LimitReader`
- Authentication error bodies (401/403) not echoed to user
- API key unexported; never in `SessionRecord`, any error message, or serialised output

## Tests

- 18 unit tests in `llm/extract_test.go` (all code paths including refusal, malformed, empty, preamble stripping, draft validation failure, missing prompt template, etc.)
- 5 unit tests in `llm/client_test.go`, 4 in `llm/prompt_test.go`
- 11 CLI integration tests in `cmd/meshant/cmd_extract_test.go` (happy path, error paths, session output defaulting, criterion file, cwd-stdout defaulting)

## What was changed

- `meshant/llm/` — new package (7 files: types, client, prompt, extract + 3 test files)
- `meshant/cmd/meshant/cmd_extract.go` — extract subcommand
- `meshant/cmd/meshant/cmd_extract_test.go` — CLI tests
- `meshant/cmd/meshant/main.go` — `run()` dispatch, `usage()`, package doc
- `docs/CODEMAPS/meshant.md` — new `llm` package section, updated `cmd/meshant` section, LLM extraction pipeline data flow
- `tasks/todo.md` — F.2 marked complete

## Architectural notes (deferred to F.6)

1. `ExtractionConditions` name is extraction-specific; may rename to `SessionConditions` in F.6
2. `parseResponse` bracket-finding is pragmatic but fragile for nested-array LLM output
3. Refusal detection is English-only (heuristic)
4. `max_tokens: 4096` hardcoded in `AnthropicClient.Complete`
5. Full prompt text stored in `SessionRecord.Conditions.SystemInstructions`

Closes #118