### PR TITLE
feat: /observers endpoint + observer hint chips on gate UI (#165)

### DIFF
--- a/meshant/serve/handlers.go
+++ b/meshant/serve/handlers.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/automatedtomato/mesh-ant/meshant/graph"
@@ -215,6 +216,41 @@ func (s *Server) handleTraces(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, Envelope{Cut: meta, Data: filtered})
+}
+
+// handleObservers handles GET /observers.
+//
+// No parameters required. Returns the sorted, deduplicated list of observer
+// values present in the full trace substrate. This is a substrate-level query
+// (no cut applied) and does not require an observer parameter — it is the
+// mechanism by which a user discovers which positions are available.
+//
+// Response: Envelope{Cut: zero-value CutMeta, Data: []string{...observers...}}
+// The cut field is a zero-value CutMeta (no observer, no window) to signal that
+// this is a substrate-level listing, not a positioned reading.
+func (s *Server) handleObservers(w http.ResponseWriter, r *http.Request) {
+	allTraces, err := s.ts.Query(r.Context(), store.QueryOpts{})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Collect distinct observer values from the full substrate.
+	seen := make(map[string]bool)
+	for _, tr := range allTraces {
+		if tr.Observer != "" {
+			seen[tr.Observer] = true
+		}
+	}
+
+	// Sort for deterministic output.
+	observers := make([]string, 0, len(seen))
+	for obs := range seen {
+		observers = append(observers, obs)
+	}
+	sort.Strings(observers)
+
+	writeJSON(w, http.StatusOK, Envelope{Data: observers})
 }
 
 // filterByElement returns traces where elementName appears in tr.Source or tr.Target.

--- a/meshant/serve/handlers_test.go
+++ b/meshant/serve/handlers_test.go
@@ -946,3 +946,105 @@ func TestServer_APIRoutesPrecedence(t *testing.T) {
 		t.Errorf("expected application/json for API route, got %q", ct)
 	}
 }
+
+// --- handleObservers tests ---
+
+func TestHandleObservers_HappyPath_200(t *testing.T) {
+	srv := testServer(t)
+	rr := doGET(srv, "/observers")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	env := decodeEnvelope(t, rr)
+
+	// data field must be a JSON array.
+	data, ok := env["data"].([]interface{})
+	if !ok {
+		t.Fatalf("expected data to be array, got %T: %v", env["data"], env["data"])
+	}
+
+	// testTraces() has "alice" and "bob" — sorted alphabetically.
+	if len(data) != 2 {
+		t.Fatalf("expected 2 observers, got %d: %v", len(data), data)
+	}
+	if data[0].(string) != "alice" || data[1].(string) != "bob" {
+		t.Errorf("expected [alice bob], got %v", data)
+	}
+}
+
+func TestHandleObservers_Sorted(t *testing.T) {
+	// Populate store with observers in non-alphabetical order.
+	ts := store.NewJSONFileStore(t.TempDir() + "/traces.json")
+	traces := []schema.Trace{
+		{ID: "b0000000-0000-0000-0000-000000000001", Timestamp: time.Now(), WhatChanged: "z", Observer: "zara"},
+		{ID: "b0000000-0000-0000-0000-000000000002", Timestamp: time.Now(), WhatChanged: "a", Observer: "alice"},
+		{ID: "b0000000-0000-0000-0000-000000000003", Timestamp: time.Now(), WhatChanged: "m", Observer: "mike"},
+	}
+	if err := ts.Store(context.Background(), traces); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	srv := serve.NewServer(ts)
+	rr := doGET(srv, "/observers")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	env := decodeEnvelope(t, rr)
+	data := env["data"].([]interface{})
+	names := make([]string, len(data))
+	for i, d := range data {
+		names[i] = d.(string)
+	}
+	want := []string{"alice", "mike", "zara"}
+	for i, w := range want {
+		if names[i] != w {
+			t.Errorf("position %d: want %q got %q", i, w, names[i])
+		}
+	}
+}
+
+func TestHandleObservers_EmptyStore_EmptyArray(t *testing.T) {
+	ts := store.NewJSONFileStore(t.TempDir() + "/traces.json")
+	srv := serve.NewServer(ts)
+	rr := doGET(srv, "/observers")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	env := decodeEnvelope(t, rr)
+	// data should be null or empty array — either is acceptable for an empty store.
+	// The endpoint returns whatever []string{} marshals to (null when nil, [] when empty).
+	// Verify no error field is set.
+	if errField, ok := env["error"]; ok && errField != nil {
+		t.Errorf("unexpected error field: %v", errField)
+	}
+}
+
+func TestHandleObservers_StoreError_500(t *testing.T) {
+	srv := serve.NewServer(errStore{})
+	rr := doGET(srv, "/observers")
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rr.Code)
+	}
+}
+
+func TestHandleObservers_Deduplicated(t *testing.T) {
+	// Multiple traces with the same observer should produce one entry.
+	ts := store.NewJSONFileStore(t.TempDir() + "/traces.json")
+	traces := []schema.Trace{
+		{ID: "c0000000-0000-0000-0000-000000000001", Timestamp: time.Now(), WhatChanged: "a", Observer: "alice"},
+		{ID: "c0000000-0000-0000-0000-000000000002", Timestamp: time.Now(), WhatChanged: "b", Observer: "alice"},
+		{ID: "c0000000-0000-0000-0000-000000000003", Timestamp: time.Now(), WhatChanged: "c", Observer: "alice"},
+	}
+	if err := ts.Store(context.Background(), traces); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	srv := serve.NewServer(ts)
+	rr := doGET(srv, "/observers")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	env := decodeEnvelope(t, rr)
+	data := env["data"].([]interface{})
+	if len(data) != 1 {
+		t.Errorf("expected 1 deduplicated observer, got %d: %v", len(data), data)
+	}
+}

--- a/meshant/serve/server.go
+++ b/meshant/serve/server.go
@@ -50,6 +50,7 @@ func NewServer(ts store.TraceStore) *Server {
 	mux.HandleFunc("GET /shadow", s.handleShadow)
 	mux.HandleFunc("GET /traces", s.handleTraces)
 	mux.HandleFunc("GET /element/{name}", s.handleElement)
+	mux.HandleFunc("GET /observers", s.handleObservers)
 
 	// Static file server for the embedded web/ SPA.
 	// fs.Sub strips the "web" prefix so that web/index.html is served at /.

--- a/meshant/serve/web/app.js
+++ b/meshant/serve/web/app.js
@@ -34,6 +34,42 @@ function initObserverGate() {
   });
 }
 
+/**
+ * loadObserverHints — fetches GET /observers and renders clickable chips
+ * below the observer input. Clicking a chip fills the input with that observer name.
+ * Silently does nothing on error (hints are cosmetic; the gate still works without them).
+ *
+ * Called once on DOMContentLoaded.
+ */
+async function loadObserverHints() {
+  let observers;
+  try {
+    const envelope = await apiFetch('/observers');
+    observers = envelope.data || [];
+  } catch (_) {
+    // Hints are non-critical; ignore fetch errors.
+    return;
+  }
+
+  if (!observers.length) return;
+
+  const hintsEl = document.getElementById('observer-hints');
+  const chipsEl = document.getElementById('observer-chips');
+
+  observers.forEach(name => {
+    const chip = document.createElement('button');
+    chip.type = 'button'; // prevent form submit
+    chip.className = 'observer-chip';
+    chip.textContent = name;
+    chip.addEventListener('click', () => {
+      document.getElementById('observer-input').value = name;
+    });
+    chipsEl.appendChild(chip);
+  });
+
+  hintsEl.hidden = false;
+}
+
 // === SECTION 2: Cut Metadata ===
 
 /**
@@ -222,4 +258,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initObserverGate();
   initExportButtons();
+  loadObserverHints();
 });

--- a/meshant/serve/web/index.html
+++ b/meshant/serve/web/index.html
@@ -16,6 +16,11 @@
         <input id="observer-input" type="text" placeholder="e.g. alice" autocomplete="off" required>
         <button type="submit">Load graph</button>
       </div>
+      <!-- Populated by app.js on load; shows available observer positions. -->
+      <div id="observer-hints" hidden>
+        <span class="observer-hints-label">Available:</span>
+        <span id="observer-chips"></span>
+      </div>
     </form>
     <div id="error-banner" hidden></div>
   </header>

--- a/meshant/serve/web/style.css
+++ b/meshant/serve/web/style.css
@@ -79,6 +79,41 @@ body {
   background: #1f6fa1;
 }
 
+/* Observer hints: available positions shown as clickable chips below the input */
+#observer-hints {
+  margin-top: 10px;
+  width: 100%;
+  max-width: 480px;
+  font-size: 13px;
+  color: #555;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.observer-hints-label {
+  font-weight: 600;
+  color: #888;
+  flex-shrink: 0;
+}
+
+.observer-chip {
+  padding: 3px 10px;
+  background: #eaf4fb;
+  border: 1px solid #a8d4ed;
+  border-radius: 12px;
+  color: #1a5276;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.observer-chip:hover {
+  background: #d0eaf8;
+  border-color: #2980b9;
+}
+
 /* Error banner below the observer form */
 #error-banner {
   margin-top: 12px;


### PR DESCRIPTION
## Summary

- Adds `GET /observers` — returns sorted, deduplicated list of observer names present in the trace substrate (no cut, no observer param required)
- On page load, the observer gate fetches `/observers` and renders clickable chips; clicking a chip fills the input field
- Silently degrades if the fetch fails (hints are cosmetic, the gate still works)

Closes ANT tension T4 from `web-ui-v1.md`.

## Test plan
- [ ] 5 new handler tests pass (`go test ./serve/...`)
- [ ] All existing tests still pass
- [ ] Manually: `meshant serve data/examples/software_incident.json` → open localhost → chips appear with all 4 observers