### PR TITLE
feat: add SubKind endorsement field to DraftStepClassification (#96)

### DIFF
--- a/meshant/loader/draftchain.go
+++ b/meshant/loader/draftchain.go
@@ -44,6 +44,12 @@ const (
 	DraftTranslation DraftStepKind = "translation"
 )
 
+// DraftSubKindEndorsement is the SubKind value for a DraftMediator step where
+// the stage advanced but no content field changed — the derivation act was an
+// endorsement: it transformed the draft's epistemic standing without
+// reformulating its content.
+const DraftSubKindEndorsement = "endorsement"
+
 // DraftStepClassification records the classification of one derivation step (chain[i-1]→chain[i]).
 type DraftStepClassification struct {
 	// StepIndex is the destination draft's index in the chain (1 = first step).
@@ -54,6 +60,12 @@ type DraftStepClassification struct {
 
 	// Reason is a human-readable justification. Always non-empty.
 	Reason string
+
+	// SubKind qualifies the Kind when a more specific classification is
+	// warranted. Currently only set for DraftMediator steps:
+	// "endorsement" when the step is stage-only (no content change).
+	// Empty for all other kinds and for content-change mediator steps.
+	SubKind string `json:"sub_kind,omitempty"`
 }
 
 // FollowDraftChain traverses DerivedFrom links starting from from, returning drafts
@@ -121,34 +133,41 @@ func ClassifyDraftChain(chain []schema.TraceDraft) []DraftStepClassification {
 	for i := 1; i < len(chain); i++ {
 		prev := chain[i-1]
 		curr := chain[i]
-		kind, reason := classifyDraftStep(prev, curr)
+		kind, reason, subKind := classifyDraftStep(prev, curr)
 		result[i-1] = DraftStepClassification{
 			StepIndex: i,
 			Kind:      kind,
 			Reason:    reason,
+			SubKind:   subKind,
 		}
 	}
 	return result
 }
 
 // classifyDraftStep applies the v1 heuristic to a single derivation step.
-func classifyDraftStep(prev, curr schema.TraceDraft) (DraftStepKind, string) {
+// Returns (kind, reason, subKind). subKind is non-empty only for stage-only
+// DraftMediator steps, where it is set to DraftSubKindEndorsement.
+func classifyDraftStep(prev, curr schema.TraceDraft) (DraftStepKind, string, string) {
 	content := draftContentChanged(prev, curr)
 	stage := draftStageChanged(prev, curr)
 
 	switch {
 	case content && stage:
 		return DraftTranslation,
-			"content fields reformulated and extraction_stage advanced — interpretive frame shifted"
+			"content fields reformulated and extraction_stage advanced — interpretive frame shifted",
+			""
 	case content:
 		return DraftMediator,
-			"content fields reformulated — interpretation transformed in derivation"
+			"content fields reformulated — interpretation transformed in derivation",
+			""
 	case stage:
 		return DraftMediator,
-			"extraction_stage advanced without content change — endorsement transformed standing, not content"
+			"extraction_stage advanced without content change — endorsement transformed standing, not content",
+			DraftSubKindEndorsement
 	default:
 		return DraftIntermediary,
-			"no content fields changed — draft relayed without recorded transformation"
+			"no content fields changed — draft relayed without recorded transformation",
+			""
 	}
 }
 

--- a/meshant/loader/draftchain_test.go
+++ b/meshant/loader/draftchain_test.go
@@ -385,6 +385,172 @@ func TestClassifyDraftChain_MultiStepWithEndorsement(t *testing.T) {
 	}
 }
 
+// --- SubKind field tests (RED phase for #96) ---
+
+// TestClassifyDraftChain_EndorsementSubKind_StageOnly verifies that a stage-only
+// derivation step (no content change) is classified as DraftMediator with
+// SubKind == DraftSubKindEndorsement ("endorsement"). The stage advance
+// transforms the draft's epistemic standing without reformulating content.
+func TestClassifyDraftChain_EndorsementSubKind_StageOnly(t *testing.T) {
+	parent := schema.TraceDraft{
+		ID:              "a0000000-0000-4000-8000-000000000001",
+		SourceSpan:      "span",
+		WhatChanged:     "original framing",
+		ExtractionStage: "weak-draft",
+	}
+	child := schema.TraceDraft{
+		ID:              "b0000000-0000-4000-8000-000000000002",
+		SourceSpan:      "span",
+		WhatChanged:     "original framing", // content unchanged
+		ExtractionStage: "reviewed",         // stage advanced — endorsement
+		DerivedFrom:     parent.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{parent, child})
+	if len(classifications) != 1 {
+		t.Fatalf("classification count: got %d; want 1", len(classifications))
+	}
+	if classifications[0].Kind != loader.DraftMediator {
+		t.Errorf("kind: got %q; want %q", classifications[0].Kind, loader.DraftMediator)
+	}
+	if classifications[0].SubKind != loader.DraftSubKindEndorsement {
+		t.Errorf("sub_kind: got %q; want %q", classifications[0].SubKind, loader.DraftSubKindEndorsement)
+	}
+}
+
+// TestClassifyDraftChain_ContentMediatorHasEmptySubKind verifies that a content-change
+// mediator step (no stage change) carries an empty SubKind. SubKind is only set
+// for the stage-only endorsement path.
+func TestClassifyDraftChain_ContentMediatorHasEmptySubKind(t *testing.T) {
+	parent := schema.TraceDraft{
+		ID:              "a0000000-0000-4000-8000-000000000001",
+		SourceSpan:      "span",
+		WhatChanged:     "original framing",
+		ExtractionStage: "weak-draft",
+	}
+	child := schema.TraceDraft{
+		ID:              "b0000000-0000-4000-8000-000000000002",
+		SourceSpan:      "span",
+		WhatChanged:     "reformulated framing", // content changed
+		ExtractionStage: "weak-draft",           // stage unchanged
+		DerivedFrom:     parent.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{parent, child})
+	if len(classifications) != 1 {
+		t.Fatalf("classification count: got %d; want 1", len(classifications))
+	}
+	if classifications[0].Kind != loader.DraftMediator {
+		t.Errorf("kind: got %q; want %q", classifications[0].Kind, loader.DraftMediator)
+	}
+	if classifications[0].SubKind != "" {
+		t.Errorf("sub_kind: got %q; want empty string", classifications[0].SubKind)
+	}
+}
+
+// TestClassifyDraftChain_TranslationHasEmptySubKind verifies that a translation step
+// (content change + stage advance) has Kind == DraftTranslation and SubKind == "".
+// SubKind is not used for the translation path.
+func TestClassifyDraftChain_TranslationHasEmptySubKind(t *testing.T) {
+	parent := schema.TraceDraft{
+		ID:              "a0000000-0000-4000-8000-000000000001",
+		SourceSpan:      "span",
+		WhatChanged:     "original framing",
+		ExtractionStage: "weak-draft",
+	}
+	child := schema.TraceDraft{
+		ID:              "b0000000-0000-4000-8000-000000000002",
+		SourceSpan:      "span",
+		WhatChanged:     "reformulated framing", // content changed
+		ExtractionStage: "reviewed",             // stage advanced
+		DerivedFrom:     parent.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{parent, child})
+	if len(classifications) != 1 {
+		t.Fatalf("classification count: got %d; want 1", len(classifications))
+	}
+	if classifications[0].Kind != loader.DraftTranslation {
+		t.Errorf("kind: got %q; want %q", classifications[0].Kind, loader.DraftTranslation)
+	}
+	if classifications[0].SubKind != "" {
+		t.Errorf("sub_kind: got %q; want empty string", classifications[0].SubKind)
+	}
+}
+
+// TestClassifyDraftChain_IntermediaryHasEmptySubKind verifies that an intermediary
+// step (no content change, no stage change) carries an empty SubKind.
+func TestClassifyDraftChain_IntermediaryHasEmptySubKind(t *testing.T) {
+	parent := schema.TraceDraft{
+		ID:              "a0000000-0000-4000-8000-000000000001",
+		SourceSpan:      "span",
+		WhatChanged:     "original framing",
+		ExtractionStage: "weak-draft",
+	}
+	child := schema.TraceDraft{
+		ID:              "b0000000-0000-4000-8000-000000000002",
+		SourceSpan:      "span",
+		WhatChanged:     "original framing", // unchanged
+		ExtractionStage: "weak-draft",       // unchanged
+		UncertaintyNote: "provenance note",  // provenance-only change
+		DerivedFrom:     parent.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{parent, child})
+	if len(classifications) != 1 {
+		t.Fatalf("classification count: got %d; want 1", len(classifications))
+	}
+	if classifications[0].Kind != loader.DraftIntermediary {
+		t.Errorf("kind: got %q; want %q", classifications[0].Kind, loader.DraftIntermediary)
+	}
+	if classifications[0].SubKind != "" {
+		t.Errorf("sub_kind: got %q; want empty string", classifications[0].SubKind)
+	}
+}
+
+// TestClassifyDraftChain_MultiStepSubKinds verifies per-step SubKind values across a
+// three-draft chain that includes both mediator types:
+//
+//	A → B: content-change mediator (SubKind empty)
+//	B → C: stage-only endorsement mediator (SubKind == "endorsement")
+func TestClassifyDraftChain_MultiStepSubKinds(t *testing.T) {
+	a := schema.TraceDraft{
+		ID: "a0000000-0000-4000-8000-000000000001", SourceSpan: "span",
+		WhatChanged: "original", ExtractionStage: "weak-draft",
+	}
+	b := schema.TraceDraft{
+		ID: "b0000000-0000-4000-8000-000000000002", SourceSpan: "span",
+		WhatChanged: "reformulated", ExtractionStage: "weak-draft", // content changed, stage same
+		DerivedFrom: a.ID,
+	}
+	c := schema.TraceDraft{
+		ID: "c0000000-0000-4000-8000-000000000003", SourceSpan: "span",
+		WhatChanged: "reformulated", ExtractionStage: "reviewed", // stage advanced, content same
+		DerivedFrom: b.ID,
+	}
+
+	classifications := loader.ClassifyDraftChain([]schema.TraceDraft{a, b, c})
+	if len(classifications) != 2 {
+		t.Fatalf("multi-step: got %d classifications; want 2", len(classifications))
+	}
+
+	// Step A→B: content mediator — SubKind must be empty.
+	if classifications[0].Kind != loader.DraftMediator {
+		t.Errorf("step 0 kind: got %q; want %q", classifications[0].Kind, loader.DraftMediator)
+	}
+	if classifications[0].SubKind != "" {
+		t.Errorf("step 0 sub_kind: got %q; want empty string", classifications[0].SubKind)
+	}
+
+	// Step B→C: endorsement mediator — SubKind must be DraftSubKindEndorsement.
+	if classifications[1].Kind != loader.DraftMediator {
+		t.Errorf("step 1 kind: got %q; want %q", classifications[1].Kind, loader.DraftMediator)
+	}
+	if classifications[1].SubKind != loader.DraftSubKindEndorsement {
+		t.Errorf("step 1 sub_kind: got %q; want %q", classifications[1].SubKind, loader.DraftSubKindEndorsement)
+	}
+}
+
 // TestFollowDraftChain_Fork verifies that when a parent has two children,
 // FollowDraftChain follows exactly one branch (the first child by input order)
 // and returns a linear chain — not both branches. This documents the


### PR DESCRIPTION
## Summary

- Adds `DraftSubKindEndorsement = "endorsement"` constant
- Adds `SubKind string \`json:"sub_kind,omitempty"\`` to `DraftStepClassification`
- `classifyDraftStep` returns `(kind, reason, subKind)` — sets `DraftSubKindEndorsement` for stage-only mediator steps
- All other steps have `SubKind == ""` (omitted from JSON)

## ANT motivation

Stage-only endorsement (where `extraction_stage` advances but no content changes) was classified as `DraftMediator` with a reason string — callers could only distinguish it by parsing the `Reason` string. `SubKind` makes the endorsement sub-type a first-class field, visible without string inspection.

## Tests

5 new tests covering all 4 kind × subkind combinations + multi-step chain. loader coverage: 93.9%.

Closes #96