### PR TITLE
feat: Web UI time window picker (#180)

### DIFF
--- a/docs/decisions/time-window-controls-v1.md
+++ b/docs/decisions/time-window-controls-v1.md
@@ -1,0 +1,118 @@
+# Decision Record: Web UI Time Window Controls (v1)
+
+**Issue:** #180 — Web UI time series controls
+**Date:** 2026-03-28
+**Status:** Accepted
+**Files:** `meshant/serve/web/app.js`, `index.html`, `style.css`
+**Depends on:** `web-ui-v1.md`, `time-window-v1.md`
+
+---
+
+## Context
+
+The backend already supports `?from=RFC3339&to=RFC3339` query parameters on
+`/articulate`, `/shadow`, `/element/{name}`, and `/traces`. The web UI always
+sent unbounded requests, so the time window axis was inaccessible from the browser.
+
+This record documents the UI design decisions and named tensions.
+
+---
+
+## Decisions
+
+### D1: datetime-local inputs, not a range slider
+
+Two `<input type="datetime-local">` fields (From / To) were chosen over a
+range slider or date-picker library. Rationale:
+
+- No dependency on an external library (consistent with `web-ui-v1.md D3`: no
+  build step, no npm)
+- Works without a timeline view or trace density preview, which would require
+  a separate API endpoint or client-side pre-fetch
+- An analyst who knows the approximate temporal range of their dataset can
+  type or select the bounds directly
+- A slider would imply continuous density; the trace substrate is sparse and
+  discontinuous (see T4 below)
+
+### D2: Observer-gate pattern extended to the time picker
+
+`#time-window-picker` is hidden until a successful `loadGraph()` call.
+It appears and disappears in lockstep with `#cut-header` and `#main`.
+
+No time window can be set from a positionless vantage. This enforces the same
+structural constraint as the observer gate: a cut requires a position before
+it can be further constrained.
+
+### D3: Apply is explicit; time inputs do not auto-reload
+
+The From/To inputs do not trigger a reload on `change` or `blur`. An explicit
+**Apply** button is required to commit the window. Rationale:
+
+- Each `loadGraph()` call is a server round-trip; auto-firing on each keystroke
+  would be noisy and expensive
+- The analyst should be able to adjust both bounds before committing the cut
+
+### D4: "Reset to unbounded" naming
+
+The reset button is labelled "Reset to unbounded", not "Clear". An unbounded
+time window is not the absence of a temporal constraint — it is the constraint
+"include all traces regardless of timestamp" (`time-window-v1.md Decision 2`).
+"Clear" would imply the constraint is removed; "Reset to unbounded" names the
+state the analyst is moving to.
+
+### D5: Observer change resets the time window
+
+When the observer form is submitted with a new observer, `currentFrom` and
+`currentTo` are reset to `''` (unbounded). The time inputs are also cleared.
+The new observer's view is loaded with no time constraint.
+
+Rationale: a time window chosen while reading from position A may be
+meaningless, misleading, or silently narrow for position B. Starting unbounded
+on each observer change is the safer default — the analyst can re-apply the
+window explicitly if the same bounds are relevant.
+
+### D6: `toRFC3339` assumes UTC
+
+`datetime-local` inputs provide no timezone information. The conversion function
+appends `:00Z` (or `Z` if seconds are present) to produce a UTC RFC3339 string.
+This is the simplest correct implementation: all trace timestamps in MeshAnt
+are stored as RFC3339 UTC, so UTC is the appropriate reference frame for
+temporal queries.
+
+---
+
+## Tensions
+
+| ID | Description | Status |
+|----|-------------|--------|
+| T1 | UTC assumption in `toRFC3339` — traces from other timezones may be unexpectedly included/excluded | Named, deferred |
+| T2 | Observer change resets window — silently discards a user constraint that might have been intentional | Named, defensible default |
+| T3 | "Reset to unbounded" names a state, but users may expect "Clear" — the label is ANT-correct but unconventional | Named, accepted |
+| T4 | datetime-local presents a continuous time axis; trace reality is discontinuous — analyst may set a window over a temporal void and receive an empty graph without knowing why | Named, deferred |
+
+---
+
+## Deferred items
+
+- **D-1:** Temporal density indicator (T4) — surface trace min/max timestamps
+  or a density preview near the time picker so analysts can calibrate their
+  window against actual data distribution.
+
+- **D-2:** Timezone selection (T1) — if the trace store accumulates data from
+  multiple timezones, a timezone selector adjacent to the From/To inputs would
+  make the UTC assumption explicit and user-adjustable.
+
+- **D-3:** Tag filter controls — the backend already supports `?tags=` on all
+  endpoints. The time-window picker bar establishes the visual pattern (dark bar
+  between cut header and main) that a tag filter bar could follow. Candidate for
+  a follow-up issue after `#181`+.
+
+---
+
+## Relation to prior records
+
+- **`web-ui-v1.md`**: this record extends the UI with a new cut axis. Observer
+  gate pattern (`web-ui-v1.md D4`) is preserved and extended (D2 above).
+- **`time-window-v1.md`**: the backend `TimeWindow` type (decisions 1–7 there)
+  is what the UI now exposes. Decision 2 there ("zero TimeWindow = full temporal
+  cut") is what "Reset to unbounded" communicates in the UI.

--- a/meshant/serve/handlers_test.go
+++ b/meshant/serve/handlers_test.go
@@ -390,6 +390,45 @@ func TestHandleShadow_NoShadow_EmptyArray(t *testing.T) {
 	}
 }
 
+// TestHandleShadow_WithTimeWindow verifies that the shadow handler applies the
+// time window to alice's cut. With from=2026-01-02, only alice's second trace
+// passes the filter (element-b → element-c). Element-a (from alice's first
+// trace, 2026-01-01) drops into alice's shadow alongside bob's elements,
+// so the shadow set is larger than in the unbounded case.
+//
+// This test closes the cut-consistency gap identified in the #180 QA review:
+// the articulate and shadow endpoints must both apply the time window so the
+// two parallel fetches in loadGraph() produce a consistent cut.
+func TestHandleShadow_WithTimeWindow(t *testing.T) {
+	srv := testServer(t)
+	// from=2026-01-02 excludes alice's trace 1 (2026-01-01).
+	// alice's windowed cut sees only element-b and element-c.
+	// Shadow must include element-a (now outside the window) + bob's elements.
+	rr := doGET(srv, "/shadow?observer=alice&from=2026-01-02T00:00:00Z")
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	env := decodeEnvelope(t, rr)
+	cut := cutField(t, env)
+
+	if cut["observer"] != "alice" {
+		t.Errorf("cut.observer should be 'alice', got %v", cut["observer"])
+	}
+	if cut["from"] == nil {
+		t.Errorf("cut.from should be populated when ?from= is given")
+	}
+
+	data, ok := env["data"].([]interface{})
+	if !ok {
+		t.Fatalf("data should be an array, got %T: %v", env["data"], env["data"])
+	}
+	// Without a time window, alice's shadow is bob's 3 elements (x, y, z).
+	// With from=2026-01-02, element-a drops into shadow too — expect >= 4 elements.
+	if len(data) < 4 {
+		t.Errorf("shadow data should have >= 4 elements with from filter (element-a now in shadow), got %d", len(data))
+	}
+}
+
 // --- /traces tests ---
 
 func TestHandleTraces_MissingObserver_400(t *testing.T) {

--- a/meshant/serve/web/app.js
+++ b/meshant/serve/web/app.js
@@ -9,13 +9,21 @@
 //   → renderShadowPanel(shadowData, ...)         [render.js]
 //   → setLastArticulateEnvelope(envelope)        [export.js]
 //   → node click → handleNodeClick(name)
-//       → fetch /element/{name}?observer=...
+//       → fetch /element/{name}?observer=...&from=...&to=...
 //       → renderDetailPanel(name, traces, ...)   [render.js]
+//
+// Time window state (currentFrom / currentTo) is wired in SECTION 6.
+// All API calls append buildWindowParams() to include the active window.
 
 // === SECTION 1: Observer Gate ===
 
-// Module-level state: current observer position and last API responses.
+// Module-level state: current observer position and active time window.
+// currentFrom / currentTo are RFC3339 strings or '' (unbounded).
+// They are reset to '' whenever the observer changes (observer gate pattern:
+// a new observer position implies a fresh, unconstrained reading by default).
 let currentObserver = '';
+let currentFrom = '';
+let currentTo = '';
 
 /**
  * initObserverGate — wires up the #observer-form submit handler.
@@ -29,6 +37,15 @@ function initObserverGate() {
     const value = input.value.trim();
     if (!value) return;
     currentObserver = value;
+
+    // Reset time window when observer changes — a new observer position should
+    // not silently inherit the previous observer's time constraint (T2 tension:
+    // see time-window-controls-v1.md; resetting is the safer default).
+    currentFrom = '';
+    currentTo = '';
+    document.getElementById('time-from').value = '';
+    document.getElementById('time-to').value = '';
+
     clearError();
     await loadGraph();
   });
@@ -70,11 +87,56 @@ async function loadObserverHints() {
   hintsEl.hidden = false;
 }
 
-// === SECTION 2: Cut Metadata ===
+// === SECTION 2: Time Window Helpers ===
+
+/**
+ * toRFC3339 — converts a datetime-local input value to an RFC3339 UTC string.
+ *
+ * The datetime-local input yields values in two forms depending on the browser:
+ *   "YYYY-MM-DDThh:mm"    — no seconds, no timezone (most browsers)
+ *   "YYYY-MM-DDThh:mm:ss" — with seconds, no timezone (some browsers)
+ * Neither form includes a timezone offset. We append seconds (if absent) and
+ * 'Z' to produce a valid RFC3339 UTC string.
+ *
+ * ANT tension T1: this imposes a UTC temporal frame on the cut. Traces whose
+ * original timestamps use other timezone offsets may be unexpectedly included
+ * or excluded. Named tension; not resolved in v1.
+ *
+ * @param {string} val — datetime-local value or empty string.
+ * @returns {string} RFC3339 UTC string, or '' if val is empty.
+ */
+function toRFC3339(val) {
+  if (!val) return '';
+  // Append ':00' if seconds are absent (value ends with "hh:mm" pattern),
+  // then append 'Z' for UTC. datetime-local never emits a timezone offset,
+  // so no offset-stripping is needed.
+  const withSeconds = /T\d{2}:\d{2}$/.test(val) ? val + ':00' : val;
+  return withSeconds + 'Z';
+}
+
+/**
+ * buildWindowParams — constructs the from/to query string fragment for API calls.
+ *
+ * Returns '&from=RFC3339&to=RFC3339', '&from=RFC3339', '&to=RFC3339', or ''
+ * depending on which of currentFrom / currentTo are set. The leading '&' is
+ * intentional: callers always have at least one prior param (observer=...).
+ *
+ * @returns {string}
+ */
+function buildWindowParams() {
+  let params = '';
+  if (currentFrom) params += `&from=${encodeURIComponent(currentFrom)}`;
+  if (currentTo) params += `&to=${encodeURIComponent(currentTo)}`;
+  return params;
+}
+
+// === SECTION 3: Cut Metadata (renderCutMeta) ===
 
 /**
  * renderCutMeta — populates the #cut-header bar fields with CutMeta values.
  * Shows "unbounded" when from/to are null; tags as comma-separated or "none".
+ * The from/to values come from the server response (CutMeta), not from
+ * currentFrom/currentTo, so the bar always reflects the actual applied cut.
  *
  * @param {Object} cut — CutMeta object from the /articulate Envelope.
  */
@@ -92,31 +154,36 @@ function renderCutMeta(cut) {
   document.getElementById('cut-shadow-count').textContent = `Shadow: ${cut.shadow_count}`;
 }
 
-// === SECTION 3: Graph Rendering (Cytoscape) ===
+// === SECTION 4: Graph Rendering (Cytoscape) ===
 
 /**
  * loadGraph — fetches /articulate and /shadow in parallel for the current
- * observer, then renders the graph + shadow panel and shows the main layout.
+ * observer and active time window, then renders the graph + shadow panel
+ * and shows the main layout.
  *
- * On success: shows #cut-header and #main; calls renderCutMeta, initGraph,
- * renderShadowPanel. On API error: shows the error banner and leaves the layout
- * hidden until the user retries.
+ * On success: shows #cut-header, #time-window-picker, and #main; calls
+ * renderCutMeta, initGraph, renderShadowPanel. On API error: hides all three
+ * so no stale cut is displayed (ANT: a mislabelled cut is an integrity violation).
  */
 async function loadGraph() {
   const observer = currentObserver;
   if (!observer) return;
 
+  // buildWindowParams() appends &from=...&to=... if a time window is active.
+  const windowParams = buildWindowParams();
+
   try {
-    // Fetch /articulate and /shadow in parallel — both require the same observer.
+    // Fetch /articulate and /shadow in parallel — both receive the same observer
+    // and time window so the cut is consistent across the two responses.
     const [articulateEnv, shadowEnv] = await Promise.all([
-      apiFetch(`/articulate?observer=${encodeURIComponent(observer)}`),
-      apiFetch(`/shadow?observer=${encodeURIComponent(observer)}`),
+      apiFetch(`/articulate?observer=${encodeURIComponent(observer)}${windowParams}`),
+      apiFetch(`/shadow?observer=${encodeURIComponent(observer)}${windowParams}`),
     ]);
 
-    // Store the full articulate envelope for export.
+    // Store the full articulate envelope for export (includes cut.from/cut.to).
     setLastArticulateEnvelope(articulateEnv);
 
-    // Update cut header.
+    // Update cut header — from/to come from server CutMeta, not client state.
     renderCutMeta(articulateEnv.cut);
 
     // Render graph (Cytoscape).
@@ -127,8 +194,10 @@ async function loadGraph() {
     const shadowData = shadowEnv.data || [];
     renderShadowPanel(shadowData, (name) => handleNodeClick(name));
 
-    // Show the main layout; hide observer gate's extra vertical padding.
+    // Show the main layout and the time window picker (observer gate pattern:
+    // the picker is only meaningful once an observer has been committed).
     document.getElementById('cut-header').hidden = false;
+    document.getElementById('time-window-picker').hidden = false;
     document.getElementById('main').hidden = false;
 
   } catch (err) {
@@ -136,17 +205,21 @@ async function loadGraph() {
     // UI does not display a cut that names a different position than the current
     // error state — an ANT violation (the displayed cut would be mislabelled).
     document.getElementById('cut-header').hidden = true;
+    document.getElementById('time-window-picker').hidden = true;
     document.getElementById('main').hidden = true;
     showError(err.message || 'Failed to load graph. Check the observer name and try again.');
   }
 }
 
 // === SECTION 5: Node Click + Detail Panel ===
-// (Section 4 is shadow panel — rendered in render.js via renderShadowPanel.)
+// (Shadow panel — Section 3b — is rendered in render.js via renderShadowPanel.
+//  Time window picker init — Section 6 — follows below.)
 
 /**
  * handleNodeClick — called when a graph node or shadow item is clicked.
- * Fetches /element/{name}?observer=... and renders the detail panel.
+ * Fetches /element/{name}?observer=...&from=...&to=... and renders the detail
+ * panel. The time window is included so the detail panel is consistent with the
+ * current cut — showing traces outside the window would be a cut mismatch.
  *
  * @param {string} nodeName — the element name.
  */
@@ -156,7 +229,7 @@ async function handleNodeClick(nodeName) {
 
   try {
     const envelope = await apiFetch(
-      `/element/${encodeURIComponent(nodeName)}?observer=${encodeURIComponent(observer)}`
+      `/element/${encodeURIComponent(nodeName)}?observer=${encodeURIComponent(observer)}${buildWindowParams()}`
     );
     const traces = envelope.data || [];
     renderDetailPanel(nodeName, traces, observer);
@@ -168,7 +241,47 @@ async function handleNodeClick(nodeName) {
   }
 }
 
-// === SECTION 6: Export (JSON + DOT) ===
+// === SECTION 6: Time Window Picker (init) ===
+
+/**
+ * initTimeWindowPicker — wires up the Apply and Reset buttons for the time
+ * window picker. Called once on DOMContentLoaded.
+ *
+ * Apply: reads the from/to inputs, converts to RFC3339, updates module state,
+ *        and calls loadGraph() to re-fetch with the new window.
+ *
+ * Reset to unbounded: clears the inputs, resets module state to '' (unbounded),
+ *        and calls loadGraph(). "Unbounded" is a named cut state — not a missing
+ *        value — which is why the button is "Reset to unbounded", not "Clear"
+ *        (T3 tension: see time-window-controls-v1.md).
+ *
+ * ANT tension T4: the datetime-local picker presents time as a continuous,
+ * linear axis. Traces, however, are scattered and discontinuous — the picker
+ * provides no indication of where traces actually fall in time. An analyst may
+ * set a window containing no traces and receive an empty graph without knowing
+ * they are looking at a temporal void, not an empty network. Named; not resolved
+ * in v1 (a future enhancement could surface temporal trace density).
+ */
+function initTimeWindowPicker() {
+  document.getElementById('btn-apply-window').addEventListener('click', async () => {
+    const fromVal = document.getElementById('time-from').value;
+    const toVal = document.getElementById('time-to').value;
+    currentFrom = toRFC3339(fromVal);
+    currentTo = toRFC3339(toVal);
+    await loadGraph();
+  });
+
+  document.getElementById('btn-reset-window').addEventListener('click', async () => {
+    currentFrom = '';
+    currentTo = '';
+    document.getElementById('time-from').value = '';
+    document.getElementById('time-to').value = '';
+    await loadGraph();
+  });
+}
+
+// === SECTION 7: Export (JSON + DOT) ===
+// (exportJSON and exportDOT are defined in export.js; only init wiring here.)
 
 /**
  * initExportButtons — wires up the Export JSON and Export DOT button handlers.
@@ -179,7 +292,7 @@ function initExportButtons() {
   document.getElementById('btn-export-dot').addEventListener('click', exportDOT);
 }
 
-// === SECTION 7: Error Handling ===
+// === SECTION 8: Error Handling and Utilities ===
 
 /**
  * showError — displays msg in the #error-banner below the observer gate.
@@ -244,19 +357,22 @@ function escapeHTMLApp(s) {
     .replace(/"/g, '&quot;');
 }
 
-// === SECTION 8: Init ===
+// === SECTION 9: Init ===
 
 /**
  * DOMContentLoaded — entry point.
- * Hide the cut header and main area until the observer is submitted; wire up
- * all event handlers.
+ * Hide the cut header, time window picker, and main area until the observer is
+ * submitted; wire up all event handlers.
  */
 document.addEventListener('DOMContentLoaded', () => {
-  // Ensure the cut-header and main area start hidden (belt + suspenders with HTML hidden attr).
+  // Ensure the cut-header, time-window-picker, and main area start hidden
+  // (belt + suspenders with HTML hidden attr — observer gate pattern).
   document.getElementById('cut-header').hidden = true;
+  document.getElementById('time-window-picker').hidden = true;
   document.getElementById('main').hidden = true;
 
   initObserverGate();
+  initTimeWindowPicker();
   initExportButtons();
   loadObserverHints();
 });

--- a/meshant/serve/web/index.html
+++ b/meshant/serve/web/index.html
@@ -44,6 +44,23 @@
     </div>
   </div>
 
+  <!-- Time window picker: visible after observer is committed.
+       Sits between the cut header and main layout so it reads as part of the cut
+       definition — the time window is a parameter of the positioned reading, not
+       a navigation control. Disabled/hidden before observer commit (observer gate
+       pattern). -->
+  <div id="time-window-picker" hidden>
+    <span class="time-window-label">Time window</span>
+    <label for="time-from" class="time-window-field-label">From</label>
+    <input id="time-from" type="datetime-local" title="From (UTC assumed)">
+    <label for="time-to" class="time-window-field-label">To</label>
+    <input id="time-to" type="datetime-local" title="To (UTC assumed)">
+    <button id="btn-apply-window" type="button">Apply</button>
+    <!-- "Reset to unbounded" — not "Clear": unbounded is a named cut state,
+         not the absence of a window. -->
+    <button id="btn-reset-window" type="button">Reset to unbounded</button>
+  </div>
+
   <!-- Main layout: graph canvas + sidebar (shadow panel + detail panel). -->
   <div id="main" hidden>
     <div id="cy"></div>

--- a/meshant/serve/web/style.css
+++ b/meshant/serve/web/style.css
@@ -172,6 +172,87 @@ body {
   color: #fff;
 }
 
+/* === Time window picker === */
+/* Sits directly below the cut header; uses a slightly lighter dark shade to
+   visually group it with the cut metadata bar while remaining distinct.
+   Hidden until the observer is committed (observer gate pattern). */
+#time-window-picker {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 16px;
+  background: #34495e;
+  color: #bdc3c7;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.time-window-label {
+  font-weight: 600;
+  color: #95a5a6;
+  margin-right: 4px;
+  white-space: nowrap;
+}
+
+.time-window-field-label {
+  color: #95a5a6;
+  white-space: nowrap;
+}
+
+/* datetime-local inputs: dark background to match the cut header context. */
+#time-from,
+#time-to {
+  padding: 3px 7px;
+  font-size: 12px;
+  background: #2c3e50;
+  color: #ecf0f1;
+  border: 1px solid #7f8c8d;
+  border-radius: 3px;
+  outline: none;
+  /* Override browser default color scheme for date inputs */
+  color-scheme: dark;
+}
+
+#time-from:focus,
+#time-to:focus {
+  border-color: #2980b9;
+}
+
+/* Apply button: primary action, matches cut-header export button style. */
+#btn-apply-window {
+  padding: 4px 10px;
+  background: transparent;
+  color: #bdc3c7;
+  border: 1px solid #7f8c8d;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 11px;
+  transition: background 0.15s, color 0.15s;
+}
+
+#btn-apply-window:hover {
+  background: #3d5166;
+  color: #fff;
+}
+
+/* Reset button: de-emphasised; a named cut state, not a destructive action. */
+#btn-reset-window {
+  padding: 4px 8px;
+  background: transparent;
+  color: #7f8c8d;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 11px;
+  text-decoration: underline;
+  transition: color 0.15s;
+}
+
+#btn-reset-window:hover {
+  color: #bdc3c7;
+}
+
 /* === Main layout === */
 #main {
   display: flex;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -98,7 +98,7 @@ Deferred items resolved (v3.1.0, 2026-03-25): #95 `ClassifyDraftChainOptions`, #
 
 ### v4.x — Interactive CLI + Web UI time series (parent: #172)
 
-- [ ] **#180 — Web UI time series controls** — time window picker/slider; independent of MCP/explore
+- [x] **#180 — Web UI time series controls** — `datetime-local` From/To picker; T1–T4 documented; `TestHandleShadow_WithTimeWindow` added; `time-window-controls-v1.md`
 - [ ] **#181 — explore-v1.md decision record** (ANT gate) — mutable session observer, AnalysisSession design, SuggestionMeta, AnalysisTrace
 - [ ] **#182 — AnalysisSession types + meshant explore REPL skeleton** — `explore.NewSession`; `AnalysisTurn`; cut/quit/help commands
 - [ ] **#183 — explore commands batch 1** — articulate, shadow, window/tag filters


### PR DESCRIPTION
## What changed

Wires the web UI to the backend's existing `?from=RFC3339&to=RFC3339` query parameters, which were already supported on all four analytical endpoints but inaccessible from the browser.

**Frontend only — no backend behaviour changes.**

### Files changed

| File | Change |
|------|--------|
| `meshant/serve/web/index.html` | `#time-window-picker` bar added between `#cut-header` and `#main` |
| `meshant/serve/web/app.js` | `currentFrom`/`currentTo` state; `toRFC3339()`; `buildWindowParams()`; `loadGraph()` and `handleNodeClick()` pass the active window; `initTimeWindowPicker()` wires Apply + Reset; observer change resets window |
| `meshant/serve/web/style.css` | Dark bar matching cut-header aesthetic; compact inputs; Reset button de-emphasised |
| `meshant/serve/handlers_test.go` | `TestHandleShadow_WithTimeWindow` — closes the cut-consistency gap where `/shadow` had no time-window test |
| `docs/decisions/time-window-controls-v1.md` | New decision record: D1–D6 + T1–T4 tensions |
| `tasks/todo.md` | #180 marked complete |

## Why

Every articulation is a positioned reading. The time window is a second cut axis (alongside observer position) that narrows what is visible. Without UI controls, users could only inspect unbounded views.

## Design decisions (summary)

- **datetime-local inputs** — no external library; no build step; consistent with `web-ui-v1.md D3`
- **Observer-gate pattern extended** — time picker hidden until observer committed; observer change resets the window
- **Explicit Apply button** — prevents a round-trip on each keystroke
- **"Reset to unbounded"** — unbounded is a named cut state (`time-window-v1.md D2`), not an absence

## ANT tensions documented

| ID | Tension |
|----|---------|
| T1 | UTC assumption in `toRFC3339` — named, deferred |
| T2 | Observer change resets window — defensible default, named |
| T3 | "Reset to unbounded" naming — ANT-correct but unconventional |
| T4 | Continuous time picker vs. discontinuous trace reality — named, deferred |

## Test plan

- [x] `go test -race ./...` green (all 12 packages)
- [x] `go vet ./...` clean
- [x] `TestHandleShadow_WithTimeWindow` passes (new test)
- [ ] Manual smoke test: load UI → enter observer → picker appears → set From → Apply → graph updates → cut header shows window → click node → detail panel filtered → Reset to unbounded → graph restores → change observer → window clears

## Tradeoffs

Error branch hides the time picker (matches existing `#cut-header` hide-on-error pattern). A user who applies an invalid window loses access to the picker until they re-submit the observer form. Consistent with ANT integrity design (`web-ui-v1.md`); documented as T-new-3 in QA review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)