### PR TITLE
feat: AnalysisSession types + REPL skeleton (#182)

### DIFF
--- a/docs/decisions/explore-v1.md
+++ b/docs/decisions/explore-v1.md
@@ -228,6 +228,17 @@ Follows `meshant/review/session.go` as the reference pattern:
 The CLI (`cmd_explore.go`) wires `os.Stdin` and `os.Stdout` and calls `session.Run`.
 Nothing else touches the terminal.
 
+**D7a: No `meshant explore` subcommand (amended during #182 implementation).**
+The REPL is entered by running `meshant` directly, not `meshant explore`:
+
+- `meshant` — starts the REPL with no trace substrate
+- `meshant <traces.json>` — starts the REPL pre-loaded with the given file
+
+Any first argument that does not match a known subcommand is routed to the REPL
+and treated as a file path. The `run()` dispatcher in `main.go` accepts `in io.Reader`
+explicitly (signature: `run(in io.Reader, w io.Writer, args []string) error`) so the
+REPL dispatch path is testable without `os.Stdin`.
+
 ---
 
 ## Command set
@@ -328,7 +339,7 @@ Modified:
 
 | File | Change | Issue |
 |------|--------|-------|
-| `meshant/cmd/meshant/main.go` | Add `"explore"` case + usage line | #182 |
+| `meshant/cmd/meshant/main.go` | `len(args)==0` and `default:` → `cmdExplore`; `run()` gains `in io.Reader` param | #182 |
 
 ---
 

--- a/meshant/cmd/meshant/cmd_explore.go
+++ b/meshant/cmd/meshant/cmd_explore.go
@@ -1,0 +1,92 @@
+// cmd_explore.go wires the meshant interactive analysis session to the CLI.
+//
+// Entry point: invoked by run() in main.go when no subcommand is given or when
+// the first argument is not a known subcommand (treated as a trace file path).
+//
+//   meshant                        — REPL with no trace substrate loaded
+//   meshant <traces.json>          — REPL backed by the JSON file
+//   meshant --db bolt://localhost   — REPL backed by a Neo4j store
+//
+// All REPL logic lives in meshant/explore/session.go; this file is thin glue:
+// parse flags, open the store (if any), start the session.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/automatedtomato/mesh-ant/meshant/explore"
+	"github.com/automatedtomato/mesh-ant/meshant/store"
+)
+
+// cmdExplore is the CLI entry point for the interactive analysis session.
+//
+// in is the terminal reader (os.Stdin in production; strings.NewReader in tests).
+// w is the output writer (os.Stdout / a buffer in tests).
+// args are the arguments after the executable name — no subcommand prefix.
+//
+// When args is empty the session starts with no substrate loaded; commands that
+// require a substrate (articulate, shadow, etc.) will return an inline error.
+func cmdExplore(in io.Reader, w io.Writer, args []string) error {
+	fs := flag.NewFlagSet("meshant", flag.ContinueOnError)
+	fs.SetOutput(w)
+
+	var dbURL string
+	fs.StringVar(&dbURL, "db", "", "Neo4j bolt URL (e.g. bolt://localhost:7687)")
+	// TODO(#182 deferred): wire --analyst to NewSession so promoted traces carry
+	// a named conductor. Currently analyst is always "", which means every
+	// AnalysisTurn and any promoted AnalysisTrace will have an empty author.
+	// Must be wired by #185 (suggest) at the latest — SuggestionMeta.Analyst must
+	// be non-empty for attributable LLM suggestions. Also required for #186 (save).
+	// See explore-v1.md T2 tension.
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	fileArgs := fs.Args()
+
+	if dbURL != "" && len(fileArgs) > 0 {
+		return fmt.Errorf("meshant: --db and a file path are mutually exclusive")
+	}
+
+	ctx := context.Background()
+
+	// Open the store. ts remains nil when neither --db nor a file path is given;
+	// NewSession handles nil (commands that need the store will error inline).
+	var ts store.TraceStore
+	switch {
+	case dbURL != "":
+		s, err := openDB(ctx, dbURL)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = s.Close() }()
+		ts = s
+
+	case len(fileArgs) > 0:
+		// JSONFileStore opens lazily; no error on a non-existent path at open time
+		// (it returns an empty substrate and writes on Store calls). For a read-only
+		// explore session over an existing file this is sufficient.
+		jfs := store.NewJSONFileStore(fileArgs[0])
+		defer func() { _ = jfs.Close() }()
+		ts = jfs
+	}
+
+	s := explore.NewSession(ts, "")
+
+	if ts == nil {
+		fmt.Fprintln(w, "meshant — no trace substrate loaded")
+		fmt.Fprintln(w, "  run 'meshant <traces.json>' to load traces")
+	} else {
+		fmt.Fprintln(w, "meshant — interactive analysis session")
+	}
+	fmt.Fprintln(w, "  type 'help' for available commands, 'quit' to exit")
+
+	return s.Run(ctx, in, w)
+}

--- a/meshant/cmd/meshant/cmd_split_test.go
+++ b/meshant/cmd/meshant/cmd_split_test.go
@@ -322,7 +322,7 @@ func TestCmdSplit_helpFlag(t *testing.T) {
 func TestRun_Split_dispatch(t *testing.T) {
 	var buf bytes.Buffer
 	// run() with "split" and "--help" should not return an "unknown command" error.
-	err := run(&buf, []string{"split", "--help"})
+	err := run(strings.NewReader(""), &buf, []string{"split", "--help"})
 	// flag.ErrHelp is acceptable; "unknown command" is not.
 	if err != nil && strings.Contains(err.Error(), "unknown command") {
 		t.Errorf("run([\"split\", ...]) should dispatch to cmdSplit, not return unknown command: %v", err)

--- a/meshant/cmd/meshant/main.go
+++ b/meshant/cmd/meshant/main.go
@@ -9,7 +9,8 @@
 //
 // Usage:
 //
-//	meshant <command> [flags] <file.json>
+//	meshant [<traces.json>]          — interactive analysis session (REPL)
+//	meshant <command> [flags] ...   — one-shot analytical subcommand
 package main
 
 import (
@@ -179,7 +180,7 @@ func confirmOutput(w io.Writer, outputPath string) error {
 }
 
 func main() {
-	if err := run(os.Stdout, os.Args[1:]); err != nil {
+	if err := run(os.Stdin, os.Stdout, os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -187,9 +188,14 @@ func main() {
 
 // run is the testable CLI entry point; dispatches to the appropriate
 // subcommand handler based on args[0].
-func run(w io.Writer, args []string) error {
+//
+// No args and unrecognised args both route to the interactive REPL (cmdExplore).
+// An unrecognised args[0] is treated as a trace file path: meshant traces.json
+// opens the REPL pre-loaded with that file.
+func run(in io.Reader, w io.Writer, args []string) error {
 	if len(args) == 0 {
-		return errors.New(usage())
+		// No args: enter the interactive REPL with no substrate loaded.
+		return cmdExplore(in, w, args)
 	}
 	switch args[0] {
 	case "summarize":
@@ -221,17 +227,17 @@ func run(w io.Writer, args []string) error {
 	case "chain-diff":
 		return cmdChainDiff(w, args[1:])
 	case "review":
-		// os.Stdin is passed so interactive prompts can read from the terminal;
+		// in is passed so interactive prompts can read from the terminal;
 		// tests inject a strings.Reader instead.
-		return cmdReview(w, os.Stdin, args[1:])
+		return cmdReview(w, in, args[1:])
 	case "extract":
 		// nil client: real AnthropicClient is constructed from env at runtime;
 		// tests inject a mock.
 		return cmdExtract(w, nil, args[1:])
 	case "assist":
-		// nil client + os.Stdin: real client from env, interactive input from
+		// nil client + in: real client from env, interactive input from
 		// terminal; tests inject mock client and strings.Reader.
-		return cmdAssist(w, nil, os.Stdin, args[1:])
+		return cmdAssist(w, nil, in, args[1:])
 	case "critique":
 		// nil client: real AnthropicClient from env; tests inject a mock.
 		return cmdCritique(w, nil, args[1:])
@@ -251,7 +257,16 @@ func run(w io.Writer, args []string) error {
 	case "mcp":
 		return cmdMcp(w, args[1:])
 	default:
-		return fmt.Errorf("unknown command %q\n\n%s", args[0], usage())
+		// Help flags are surfaced as the full usage text rather than silently
+		// routing to the REPL — meshant --help or -h should show the subcommand
+		// list, not explore-session flag help.
+		if args[0] == "--help" || args[0] == "-h" {
+			return errors.New(usage())
+		}
+		// Any other unrecognised first argument (including flag-valued ones like
+		// --db) is forwarded to cmdExplore, which owns its own flag set and will
+		// return an appropriate error for unknown flags or invalid combinations.
+		return cmdExplore(in, w, args)
 	}
 }
 
@@ -260,7 +275,10 @@ func usage() string {
 	return `meshant — trace-first network analysis
 
 Usage:
-  meshant <command> [flags] <file.json>
+  meshant                           start interactive session (no substrate)
+  meshant <traces.json>             start interactive session, substrate from file
+  meshant --db bolt://... [file]    start interactive session, substrate from db
+  meshant <command> [flags] ...     run a one-shot analytical command
 
 Commands:
   summarize   load traces and print mesh summary

--- a/meshant/cmd/meshant/main_test.go
+++ b/meshant/cmd/meshant/main_test.go
@@ -97,26 +97,60 @@ func TestCmdValidate_MissingArg(t *testing.T) {
 
 // --- Group 3: run() dispatch ---
 
-// TestRun_NoArgs verifies that run() returns an error when called with an
-// empty argument slice (no subcommand).
+// TestRun_NoArgs verifies that run() with no arguments starts the interactive
+// REPL (cmdExplore) and exits cleanly on EOF — no error returned.
+// Prior to v4.x, no args returned a usage error. The behaviour changed
+// when meshant adopted the "bare meshant = REPL" pattern.
 func TestRun_NoArgs(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{})
-	if err == nil {
-		t.Error("run() with no args: want non-nil error, got nil")
+	err := run(strings.NewReader(""), &buf, []string{})
+	if err != nil {
+		t.Errorf("run() with no args: want nil (REPL exits on EOF), got %v", err)
+	}
+	// The REPL prints the nil-substrate intro message; verify the specific branch.
+	if !strings.Contains(buf.String(), "no trace substrate loaded") {
+		t.Errorf("run() with no args: expected nil-substrate message, got: %q", buf.String())
 	}
 }
 
-// TestRun_UnknownCommand verifies that run() returns an error containing
-// "unknown command" when the first argument is not a known subcommand.
-func TestRun_UnknownCommand(t *testing.T) {
+// TestRun_UnrecognisedArgRoutesToREPL verifies that run() routes an unrecognised
+// first argument to cmdExplore (treated as a trace file path) rather than returning
+// a usage error. The session opens and exits cleanly on EOF — the JSONFileStore is
+// lazy (no error at open time, only on Query).
+func TestRun_UnrecognisedArgRoutesToREPL(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{"badcmd"})
-	if err == nil {
-		t.Fatal("run() with unknown command: want non-nil error, got nil")
+	err := run(strings.NewReader(""), &buf, []string{"badcmd"})
+	// The session opens and exits via EOF; no error expected.
+	if err != nil {
+		t.Errorf("run() with unrecognised arg: want nil (REPL opens), got %v", err)
 	}
-	if !strings.Contains(err.Error(), "unknown command") {
-		t.Errorf("run() error = %q; want it to contain \"unknown command\"", err.Error())
+}
+
+// TestRun_FlagLikeArgReturnsUsage verifies that a flag-like first argument
+// (e.g. --help, -h) returns the top-level usage text rather than silently
+// opening the REPL — consistent with prior CLI behaviour.
+func TestRun_FlagLikeArgReturnsUsage(t *testing.T) {
+	var buf bytes.Buffer
+	err := run(strings.NewReader(""), &buf, []string{"--help"})
+	if err == nil {
+		t.Fatal("run([\"--help\"]) should return an error with usage text, got nil")
+	}
+	if !strings.Contains(err.Error(), "meshant") {
+		t.Errorf("run([\"--help\"]) error should contain usage text, got: %q", err.Error())
+	}
+}
+
+// TestRun_ExploreDBAndFileMutuallyExclusive verifies that passing both --db and
+// a file path to the REPL returns an error. The mutual-exclusion check at
+// cmd_explore.go line 52 must not be silently removed.
+func TestRun_ExploreDBAndFileMutuallyExclusive(t *testing.T) {
+	var buf bytes.Buffer
+	err := run(strings.NewReader(""), &buf, []string{"--db", "bolt://localhost:7687", "traces.json"})
+	if err == nil {
+		t.Fatal("run() with --db and file: want non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusion, got: %q", err.Error())
 	}
 }
 
@@ -126,7 +160,7 @@ func TestRun_UnknownCommand(t *testing.T) {
 // loader pipeline.
 func TestRun_Summarize_Integration(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{"summarize", "../../../data/examples/evacuation_order.json"})
+	err := run(strings.NewReader(""), &buf, []string{"summarize", "../../../data/examples/evacuation_order.json"})
 	if err != nil {
 		t.Fatalf("run([\"summarize\", path]) returned unexpected error: %v", err)
 	}
@@ -150,7 +184,7 @@ func TestCmdValidate_BadPath(t *testing.T) {
 // message without returning an error.
 func TestRun_Validate_Integration(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{"validate", "../../../data/examples/evacuation_order.json"})
+	err := run(strings.NewReader(""), &buf, []string{"validate", "../../../data/examples/evacuation_order.json"})
 	if err != nil {
 		t.Fatalf("run([\"validate\", path]) returned unexpected error: %v", err)
 	}
@@ -1025,7 +1059,7 @@ func TestCmdFollow_Output(t *testing.T) {
 // TestRun_Follow verifies that run() dispatches "follow" to cmdFollow.
 func TestRun_Follow(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{
+	err := run(strings.NewReader(""), &buf, []string{
 		"follow",
 		"--observer", "meteorological-analyst",
 		"--element", "buoy-array-atlantic-sector-7",
@@ -2303,7 +2337,7 @@ func TestCmdShadow_OutputToFile(t *testing.T) {
 // to cmdShadow, producing non-empty output.
 func TestCmdShadow_RunDispatch(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{
+	err := run(strings.NewReader(""), &buf, []string{
 		"shadow",
 		"--observer", "meteorological-analyst",
 		evacuationDataset,
@@ -2478,7 +2512,7 @@ func TestCmdGaps_SameObserver(t *testing.T) {
 // cmdGaps, producing non-empty output.
 func TestCmdGaps_RunDispatch(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{
+	err := run(strings.NewReader(""), &buf, []string{
 		"gaps",
 		"--observer-a", "meteorological-analyst",
 		"--observer-b", "coastal-resident",
@@ -2544,7 +2578,7 @@ func TestCmdBottleneck_MissingPath(t *testing.T) {
 // "bottleneck" to cmdBottleneck, producing non-empty output.
 func TestCmdBottleneck_RunDispatch(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{
+	err := run(strings.NewReader(""), &buf, []string{
 		"bottleneck",
 		"--observer", "meteorological-analyst",
 		evacuationDataset,
@@ -2970,7 +3004,7 @@ func TestCmdReview_EOFInput(t *testing.T) {
 // cmdReview (missing path argument) not from the dispatcher.
 func TestRun_ReviewDispatch(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{"review"})
+	err := run(strings.NewReader(""), &buf, []string{"review"})
 	if err == nil {
 		t.Fatal("run([\"review\"]) with no path: want non-nil error, got nil")
 	}
@@ -3567,7 +3601,7 @@ func TestCmdChainDiff_CyclicDerivation(t *testing.T) {
 // reaches the command (error comes from cmdPromoteSession, not the router).
 func TestRun_PromoteSession_dispatch(t *testing.T) {
 	var buf bytes.Buffer
-	err := run(&buf, []string{"promote-session", "--observer", "analyst-alice"})
+	err := run(strings.NewReader(""), &buf, []string{"promote-session", "--observer", "analyst-alice"})
 	if err == nil {
 		t.Fatal("run([\"promote-session\"]) with no --session-file: want error, got nil")
 	}

--- a/meshant/explore/explore_test.go
+++ b/meshant/explore/explore_test.go
@@ -1,0 +1,299 @@
+// Package explore_test verifies the AnalysisSession REPL using black-box tests.
+//
+// Tests use injected io.Reader / io.Writer (strings.NewReader + bytes.Buffer)
+// so no terminal is required. A real JSONFileStore backed by a temp file is used
+// instead of a mock — consistency with the actual store interface is preferred
+// over isolation from it (see review/session.go for the same pattern).
+package explore_test
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/explore"
+	"github.com/automatedtomato/mesh-ant/meshant/store"
+)
+
+// testStore returns a JSONFileStore backed by a temp file with no traces.
+// The store is closed automatically when the test ends via t.Cleanup.
+func testStore(t *testing.T) store.TraceStore {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "traces.json")
+	ts := store.NewJSONFileStore(path)
+	t.Cleanup(func() { _ = ts.Close() })
+	return ts
+}
+
+// run is a helper that runs the session with the given input and returns output.
+func run(t *testing.T, s *explore.AnalysisSession, input string) string {
+	t.Helper()
+	in := strings.NewReader(input)
+	var out bytes.Buffer
+	if err := s.Run(context.Background(), in, &out); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	return out.String()
+}
+
+// === NewSession ===
+
+func TestNewSession(t *testing.T) {
+	ts := testStore(t)
+	s := explore.NewSession(ts, "alice")
+
+	if s.Analyst() != "alice" {
+		t.Errorf("Analyst() = %q, want %q", s.Analyst(), "alice")
+	}
+	if s.Observer() != "" {
+		t.Errorf("Observer() = %q, want empty string before any cut", s.Observer())
+	}
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() len = %d, want 0 before any command", len(s.Turns()))
+	}
+}
+
+func TestNewSession_EmptyAnalyst(t *testing.T) {
+	// An empty analyst is permitted — the session works without a named conductor.
+	s := explore.NewSession(testStore(t), "")
+	if s.Analyst() != "" {
+		t.Errorf("Analyst() = %q, want empty string", s.Analyst())
+	}
+}
+
+// === Quit and EOF ===
+
+func TestRun_Quit(t *testing.T) {
+	s := explore.NewSession(testStore(t), "alice")
+	run(t, s, "quit\n")
+
+	// A bare quit records no turns — no analytical act was performed.
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d after bare quit, want 0", len(s.Turns()))
+	}
+}
+
+func TestRun_QuitAlias(t *testing.T) {
+	// "q" is accepted as an alias for "quit".
+	s := explore.NewSession(testStore(t), "alice")
+	run(t, s, "q\n")
+	// A bare 'q' records no turns — same contract as 'quit'.
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d after 'q', want 0", len(s.Turns()))
+	}
+}
+
+func TestRun_EOF(t *testing.T) {
+	// EOF on the reader is treated identically to quit — consistent with
+	// the review/session.go pattern; a closed reader is an unrecoverable state.
+	s := explore.NewSession(testStore(t), "alice")
+	run(t, s, "")
+	// EOF records no turns and leaves state unchanged.
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d after EOF, want 0", len(s.Turns()))
+	}
+	if s.Observer() != "" {
+		t.Errorf("Observer() = %q after EOF, want empty", s.Observer())
+	}
+}
+
+func TestRun_EmptyLines(t *testing.T) {
+	// Empty lines are silently skipped; session continues to quit.
+	s := explore.NewSession(testStore(t), "alice")
+	run(t, s, "\n\n\nquit\n")
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d after empty lines + quit, want 0", len(s.Turns()))
+	}
+}
+
+// === cut command ===
+
+func TestRun_Cut(t *testing.T) {
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "cut on-call-engineer\nquit\n")
+
+	if s.Observer() != "on-call-engineer" {
+		t.Errorf("Observer() = %q, want %q", s.Observer(), "on-call-engineer")
+	}
+
+	// cut prints a confirmation message containing the observer name.
+	if !strings.Contains(out, "on-call-engineer") {
+		t.Errorf("cut output should contain the observer name, got:\n%s", out)
+	}
+
+	// cut records exactly one turn.
+	turns := s.Turns()
+	if len(turns) != 1 {
+		t.Fatalf("Turns() = %d, want 1", len(turns))
+	}
+
+	// The turn records the observer that became active as a result of the cut.
+	if turns[0].Command != "cut on-call-engineer" {
+		t.Errorf("Turn.Command = %q, want %q", turns[0].Command, "cut on-call-engineer")
+	}
+	if turns[0].Observer != "on-call-engineer" {
+		t.Errorf("Turn.Observer = %q, want %q", turns[0].Observer, "on-call-engineer")
+	}
+	if turns[0].ExecutedAt.IsZero() {
+		t.Error("Turn.ExecutedAt should be non-zero")
+	}
+}
+
+func TestRun_Cut_NoArg(t *testing.T) {
+	// cut without an observer name shows an inline error; observer unchanged.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "cut\nquit\n")
+
+	if s.Observer() != "" {
+		t.Errorf("Observer() = %q after failed cut, want empty", s.Observer())
+	}
+	if !strings.Contains(out, "observer name required") {
+		t.Errorf("expected 'observer name required' in output, got:\n%s", out)
+	}
+	// No turn recorded for a failed cut.
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d after failed cut, want 0", len(s.Turns()))
+	}
+}
+
+func TestRun_MultipleCuts(t *testing.T) {
+	// Each cut records a turn; each turn snapshots the observer that became active.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	run(t, s, "cut alice\ncut bob\ncut alice\nquit\n")
+
+	if s.Observer() != "alice" {
+		t.Errorf("Observer() = %q after final cut, want %q", s.Observer(), "alice")
+	}
+
+	turns := s.Turns()
+	if len(turns) != 3 {
+		t.Fatalf("Turns() = %d, want 3", len(turns))
+	}
+
+	// The positional trajectory: alice → bob → alice
+	wantObservers := []string{"alice", "bob", "alice"}
+	for i, want := range wantObservers {
+		if turns[i].Observer != want {
+			t.Errorf("turns[%d].Observer = %q, want %q", i, turns[i].Observer, want)
+		}
+	}
+}
+
+func TestRun_Cut_SnapshotsWindow(t *testing.T) {
+	// At session start the window is zero-value; the turn records that.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	run(t, s, "cut alice\nquit\n")
+
+	turns := s.Turns()
+	if len(turns) == 0 {
+		t.Fatal("expected at least one turn")
+	}
+	if !turns[0].Window.IsZero() {
+		t.Errorf("Turn.Window should be zero before any window command, got %+v", turns[0].Window)
+	}
+}
+
+func TestRun_Cut_SnapshotsTags(t *testing.T) {
+	// At session start tags are nil; the turn records that.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	run(t, s, "cut alice\nquit\n")
+
+	turns := s.Turns()
+	if len(turns) == 0 {
+		t.Fatal("expected at least one turn")
+	}
+	if turns[0].Tags != nil {
+		t.Errorf("Turn.Tags = %v, want nil before any tags command", turns[0].Tags)
+	}
+}
+
+// === help command ===
+
+func TestRun_Help(t *testing.T) {
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "help\nquit\n")
+
+	// help output must mention all skeleton commands.
+	for _, keyword := range []string{"cut", "help", "quit"} {
+		if !strings.Contains(out, keyword) {
+			t.Errorf("help output missing %q\nfull output:\n%s", keyword, out)
+		}
+	}
+}
+
+func TestRun_HelpAlias(t *testing.T) {
+	// "h" produces the same output as "help" — all skeleton keywords present.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "h\nquit\n")
+	for _, keyword := range []string{"cut", "help", "quit"} {
+		if !strings.Contains(out, keyword) {
+			t.Errorf("help alias 'h' output missing %q\nfull output:\n%s", keyword, out)
+		}
+	}
+}
+
+// === unknown command ===
+
+func TestRun_UnknownCommand(t *testing.T) {
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "foobar\nquit\n")
+
+	// Unknown command shows an inline error; session continues.
+	if !strings.Contains(out, "unknown command") {
+		t.Errorf("expected 'unknown command' in output, got:\n%s", out)
+	}
+	// No turn recorded for an unknown command.
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d after unknown command, want 0", len(s.Turns()))
+	}
+}
+
+func TestRun_UnknownThenCut(t *testing.T) {
+	// An unknown command does not terminate the session; subsequent commands work.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	run(t, s, "foobar\ncut alice\nquit\n")
+
+	if s.Observer() != "alice" {
+		t.Errorf("Observer() = %q after unknown+cut, want %q", s.Observer(), "alice")
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+// === AnalysisTurn field access ===
+
+func TestAnalysisTurn_SuggestionNilForCut(t *testing.T) {
+	// Suggestion is non-nil only for the 'suggest' command (wired in #185).
+	s := explore.NewSession(testStore(t), "alice")
+	run(t, s, "cut on-call-engineer\nquit\n")
+
+	turns := s.Turns()
+	if len(turns) == 0 {
+		t.Fatal("expected at least one turn")
+	}
+	if turns[0].Suggestion != nil {
+		t.Errorf("Turn.Suggestion should be nil for cut command, got %+v", turns[0].Suggestion)
+	}
+}
+
+// === Turns returns a copy ===
+
+func TestTurns_ReturnsCopy(t *testing.T) {
+	// Mutations to the slice returned by Turns() must not affect the session.
+	s := explore.NewSession(testStore(t), "alice")
+	run(t, s, "cut alice\nquit\n")
+
+	copy1 := s.Turns()
+	if len(copy1) == 0 {
+		t.Fatal("expected at least one turn")
+	}
+	copy1[0].Command = "mutated"
+
+	copy2 := s.Turns()
+	if copy2[0].Command == "mutated" {
+		t.Error("Turns() returned a reference to internal state; mutation propagated")
+	}
+}

--- a/meshant/explore/session.go
+++ b/meshant/explore/session.go
@@ -1,0 +1,213 @@
+// Package explore implements the interactive analysis session for MeshAnt.
+//
+// AnalysisSession is the core type: a REPL that maintains per-session state
+// (observer, window, tags) and records each command as a positioned analytical
+// act (AnalysisTurn). The session ends on "quit" or EOF.
+//
+// Design principles:
+//   - Injected io.Reader / io.Writer make the REPL testable without a terminal.
+//   - The TraceStore is queried live on each turn — no snapshot is taken at open.
+//   - Each AnalysisTurn records the cut conditions in effect at execution time,
+//     preserving the full positional trajectory for downstream promotion.
+//   - Observer is mutable mid-session (ANT-native: shifting reading position).
+//
+// See docs/decisions/explore-v1.md for the full design rationale, including
+// ANT tensions T172.1–T172.6.
+//
+// CLI entry point: meshant/cmd/meshant/cmd_explore.go
+// Command implementations: commands.go (#183), commands_dual.go (#184),
+//   suggest.go (#185), trace.go (#186)
+package explore
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/automatedtomato/mesh-ant/meshant/graph"
+	"github.com/automatedtomato/mesh-ant/meshant/store"
+)
+
+// AnalysisSession is the in-memory state for a single interactive explore session.
+//
+// ts is queried live on each turn — the substrate does not freeze at session open
+// (D2 in explore-v1.md). This means traces added to the store while the session
+// is open are visible to subsequent turns (T172.6: the promoted trace records acts,
+// not reproducible readings — see explore-v1.md T172.6).
+//
+// turns is a linear slice in v1. Tree-structured (branching) sessions are deferred
+// to v5 — see T172.3 in explore-v1.md. The field must not bake in a topology that
+// precludes future branching.
+type AnalysisSession struct {
+	ts       store.TraceStore // injected; queried live on each turn (D2)
+	analyst  string           // who is conducting the session; stable across turns (D1)
+	observer string           // current observer position; mutable per-turn (D1)
+	window   graph.TimeWindow // session-level time window; changed by `window` command
+	tags     []string         // session-level tag filters; changed by `tags` command
+	turns    []AnalysisTurn   // ordered linear history; no branching in v1 (T172.3)
+}
+
+// NewSession creates an AnalysisSession backed by ts, identified by analyst.
+// The store is queried live on each turn — no snapshot is taken at session start (D2).
+//
+// ts may be nil when no trace substrate is loaded (e.g. meshant with no file arg).
+// Commands that require the store will return an inline error when ts is nil.
+//
+// analyst may be empty if the caller does not know who is conducting the session;
+// the session still works but promoted traces will carry an empty observer field.
+func NewSession(ts store.TraceStore, analyst string) *AnalysisSession {
+	return &AnalysisSession{
+		ts:      ts,
+		analyst: analyst,
+	}
+}
+
+// Analyst returns the session analyst name. Stable across turns.
+func (s *AnalysisSession) Analyst() string { return s.analyst }
+
+// Observer returns the current session observer position.
+// Empty until the first `cut <observer>` command.
+func (s *AnalysisSession) Observer() string { return s.observer }
+
+// Turns returns a deep-enough copy of the ordered turn history to prevent
+// callers from mutating the session's internal record.
+//
+// Each AnalysisTurn is value-copied (struct fields are copied by value). The
+// Tags slice within each turn is also deep-copied so that element mutations
+// by the caller do not propagate back into the session record. This matches
+// the deep-copy discipline applied in recordTurn.
+func (s *AnalysisSession) Turns() []AnalysisTurn {
+	result := make([]AnalysisTurn, len(s.turns))
+	for i, t := range s.turns {
+		result[i] = t
+		if len(t.Tags) > 0 {
+			tagsCopy := make([]string, len(t.Tags))
+			copy(tagsCopy, t.Tags)
+			result[i].Tags = tagsCopy
+		}
+	}
+	return result
+}
+
+// Run executes the interactive REPL loop, reading commands from in and writing
+// output to out. Blocking; returns when the analyst types "quit" or "q", or when
+// in reaches EOF.
+//
+// Follows meshant/review/session.go as the reference REPL pattern (D7):
+//   - bufio.Scanner for line reading
+//   - All output to out, never to os.Stdout directly
+//   - Testable by passing strings.NewReader and bytes.Buffer
+//
+// Run returns nil on normal exit (quit or EOF). It returns a non-nil error only
+// for unrecoverable internal errors — inline command errors are printed to out
+// and the loop continues.
+func (s *AnalysisSession) Run(ctx context.Context, in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+
+	for {
+		fmt.Fprintf(out, "meshant> ")
+		if !scanner.Scan() {
+			// EOF or scanner error — treat as quit, consistent with review/session.go.
+			// scanner.Err() is intentionally not checked here: in an interactive
+			// terminal session a closed or errored reader is an unrecoverable condition;
+			// surfacing the error would not help the analyst recover, and the session
+			// ends cleanly either way. If a command-line tool discovers this silent
+			// swallow is a problem in practice, checking scanner.Err() here is
+			// straightforward to add.
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if line == "quit" || line == "q" {
+			break
+		}
+		if err := s.dispatch(ctx, line, out); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// dispatch routes a trimmed, non-empty, non-quit command line to its handler.
+// Returns nil for unknown commands and inline errors (they are printed to out).
+// Returns a non-nil error only for unrecoverable internal failures.
+func (s *AnalysisSession) dispatch(ctx context.Context, line string, out io.Writer) error {
+	parts := strings.Fields(line)
+	if len(parts) == 0 {
+		return nil
+	}
+	cmd := parts[0]
+	args := parts[1:]
+
+	switch cmd {
+	case "cut":
+		return s.cmdCut(line, args, out)
+	case "help", "h":
+		fmt.Fprint(out, helpText())
+		return nil
+	default:
+		fmt.Fprintf(out, "unknown command %q — type 'help' for a list of commands\n", cmd)
+		return nil
+	}
+}
+
+// cmdCut changes the session observer position and records a turn.
+//
+// Usage: cut <observer>
+//
+// The turn records the observer that became active as a result of the cut
+// (not the prior observer). This preserves the positional trajectory in turns:
+// each turn.Observer shows where the analyst was reading from after that cut.
+//
+// No turn is recorded when the cut fails (e.g. missing observer name).
+func (s *AnalysisSession) cmdCut(rawLine string, args []string, out io.Writer) error {
+	if len(args) == 0 {
+		fmt.Fprintf(out, "cut: observer name required — usage: cut <observer>\n")
+		return nil // inline error; session continues
+	}
+	s.observer = args[0]
+	fmt.Fprintf(out, "observer → %s\n", s.observer)
+	s.recordTurn(rawLine, nil, nil)
+	return nil
+}
+
+// helpText returns the help listing for the skeleton command set.
+// Extended in #183–#186 as new commands are added.
+func helpText() string {
+	return `Commands:
+  cut <observer>    set the observer position for subsequent turns
+  help  (h)         show this help
+  quit  (q)         end the session; discards unsaved turns
+`
+}
+
+// recordTurn appends a new AnalysisTurn to the session history.
+//
+// Window and Tags are deep-copied so that future changes to s.window / s.tags
+// do not retroactively alter a completed turn's recorded conditions (D3).
+// Reading and Suggestion are stored by reference — their concrete types
+// (graph.MeshGraph, etc.) are immutable values from the analytical engine.
+func (s *AnalysisSession) recordTurn(command string, reading interface{}, suggestion *SuggestionMeta) {
+	// Deep-copy tags: nil input → nil copy (no empty slice created for zero-tag sessions).
+	var tagsCopy []string
+	if len(s.tags) > 0 {
+		tagsCopy = make([]string, len(s.tags))
+		copy(tagsCopy, s.tags)
+	}
+
+	s.turns = append(s.turns, AnalysisTurn{
+		Observer:   s.observer,
+		Window:     s.window, // graph.TimeWindow is a value type; no deep copy needed
+		Tags:       tagsCopy,
+		Command:    command,
+		Reading:    reading,
+		Suggestion: suggestion,
+		ExecutedAt: time.Now(),
+	})
+}

--- a/meshant/explore/session_internal_test.go
+++ b/meshant/explore/session_internal_test.go
@@ -1,0 +1,105 @@
+// session_internal_test.go — white-box tests for AnalysisSession internals.
+//
+// Uses package explore (not explore_test) to access unexported fields
+// that cannot be reached from the black-box test suite. Kept minimal: only
+// tests that genuinely require internal access belong here.
+package explore
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/automatedtomato/mesh-ant/meshant/store"
+)
+
+// testStoreInternal creates a real JSONFileStore backed by a temp file.
+// Duplicates explore_test.testStore — a deliberate copy to keep the two
+// test packages independent (no shared test helper across package boundaries).
+func testStoreInternal(t *testing.T) store.TraceStore {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "traces.json")
+	ts := store.NewJSONFileStore(path)
+	t.Cleanup(func() { _ = ts.Close() })
+	return ts
+}
+
+// TestTurns_TagsDeepCopy verifies that Turns() deep-copies the Tags slice
+// within each turn so that callers cannot mutate the session's internal record
+// by modifying returned tag elements.
+//
+// This test sets s.tags directly (white-box access) before recording a turn,
+// so the Tags branch in both recordTurn and Turns() is exercised. The test
+// will be superseded by a black-box equivalent when the `tags` command is
+// wired in #183 — at that point this internal test may be removed.
+//
+// TODO(#183): replace with black-box test once `tags` command is implemented.
+func TestTurns_TagsDeepCopy(t *testing.T) {
+	s := NewSession(testStoreInternal(t), "analyst-1")
+
+	// Directly set unexported s.tags to a non-empty slice so recordTurn
+	// records a turn with non-nil Tags, exercising both copy branches.
+	s.tags = []string{"incident", "2026"}
+
+	// Record a turn by executing a cut (the only skeleton command that records).
+	in := strings.NewReader("cut alice\nquit\n")
+	if err := s.Run(context.Background(), in, &nopWriter{}); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	turns := s.Turns()
+	if len(turns) == 0 {
+		t.Fatal("expected at least one turn after cut")
+	}
+
+	// Verify the turn recorded the tags.
+	if len(turns[0].Tags) != 2 {
+		t.Fatalf("Turn.Tags = %v, want 2 elements", turns[0].Tags)
+	}
+
+	// Mutate the returned Tags slice — the session's internal record must not change.
+	turns[0].Tags[0] = "mutated"
+
+	turns2 := s.Turns()
+	if turns2[0].Tags[0] == "mutated" {
+		t.Error("Turns() returned a reference to internal Tags; mutation propagated")
+	}
+	if turns2[0].Tags[0] != "incident" {
+		t.Errorf("turns2[0].Tags[0] = %q, want %q", turns2[0].Tags[0], "incident")
+	}
+}
+
+// TestRecordTurn_TagsDeepCopy verifies that recordTurn deep-copies s.tags
+// so that a subsequent change to s.tags does not retroactively alter a
+// completed turn's recorded conditions (D3 in explore-v1.md).
+func TestRecordTurn_TagsDeepCopy(t *testing.T) {
+	s := NewSession(testStoreInternal(t), "analyst-1")
+	s.tags = []string{"alpha"}
+
+	// Record a turn with tags = ["alpha"].
+	s.recordTurn("cut alice", nil, nil)
+	s.observer = "alice"
+
+	// Mutate s.tags after recording.
+	s.tags[0] = "mutated"
+	s.tags = append(s.tags, "beta")
+
+	// The recorded turn must still carry the original tags.
+	turns := s.Turns()
+	if len(turns) == 0 {
+		t.Fatal("expected at least one turn")
+	}
+	if len(turns[0].Tags) != 1 {
+		t.Fatalf("Turn.Tags = %v, want 1 element (snapshot at record time)", turns[0].Tags)
+	}
+	if turns[0].Tags[0] != "alpha" {
+		t.Errorf("Turn.Tags[0] = %q, want %q (snapshot must not reflect post-record mutation)", turns[0].Tags[0], "alpha")
+	}
+}
+
+// nopWriter discards all output. Used in internal tests to satisfy io.Writer
+// without importing bytes.
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/meshant/explore/turn.go
+++ b/meshant/explore/turn.go
@@ -1,0 +1,74 @@
+// turn.go defines the AnalysisTurn and SuggestionMeta types for the
+// meshant explore interactive session.
+//
+// An AnalysisTurn is a single command executed within an AnalysisSession.
+// It is a positioned analytical act: the Observer, Window, and Tags fields
+// snapshot the cut conditions in effect at execution time, and Reading holds
+// the positioned output produced by the command.
+//
+// "Reading" not "Result" — a result stands independently of its conditions;
+// a reading requires a position to be interpretable. The field name enforces
+// this at the type level.
+//
+// See docs/decisions/explore-v1.md D3 for full rationale.
+package explore
+
+import (
+	"time"
+
+	"github.com/automatedtomato/mesh-ant/meshant/graph"
+)
+
+// AnalysisTurn records a single command executed within an AnalysisSession.
+//
+// Observer, Window, and Tags are snapshotted at execution time (not at session
+// start). Changing the window or tags via the `window`/`tags` commands affects
+// future turns only — prior turns retain the conditions under which they executed,
+// preserving the full analytical record (D3 in explore-v1.md).
+//
+// Reading is interface{} in v1. Concrete types depend on the command:
+//   - cut:         nil (cut changes state; it is not itself a mesh reading)
+//   - articulate:  graph.MeshGraph
+//   - shadow:      []graph.ShadowElement
+//   - follow:      graph.TranslationChain
+//   - bottleneck:  []graph.BottleneckElement
+//   - diff:        graph.GraphDiff
+//   - gaps:        graph.GapsResult
+//   - summarize:   string
+//   - validate:    string
+//   - help:        string
+//
+// Suggestion is nil for all commands except `suggest`. When non-nil it carries
+// the full LLM provenance for that turn (wired in #185 — stub here for type
+// completeness in the skeleton).
+type AnalysisTurn struct {
+	Observer   string          // ANT position active when this turn executed
+	Window     graph.TimeWindow // time window active when this turn executed
+	Tags       []string         // tag filters active when this turn executed
+	Command    string          // the command string as typed by the analyst
+	Reading    interface{}     // positioned output — "Reading" not "Result" (see package doc)
+	Suggestion *SuggestionMeta // non-nil only when Command == "suggest" (wired in #185)
+	ExecutedAt time.Time
+}
+
+// SuggestionMeta records provenance for an LLM-generated suggestion.
+//
+// Every output of the `suggest` command carries SuggestionMeta so the
+// suggestion can be attributed to a named cut and a known substrate size.
+// An LLM suggestion without a named cut is an unattributable reading —
+// it cannot be placed in the analytical record without knowing from whose
+// position it was generated and what substrate it saw.
+//
+// This follows the same discipline as meshant/llm SuggestionMeta.
+// The LLM is a mediator: its output transforms the cut into a navigational
+// suggestion. That mediation must be visible in the session record.
+//
+// Implementation: #185. The type is declared here so that AnalysisTurn
+// compiles in the skeleton.
+type SuggestionMeta struct {
+	Analyst     string        // who asked for the suggestion
+	CutUsed     graph.CutMeta // exact cut in effect when suggest was called
+	Basis       string        // "gaps", "bottleneck", or "shadow" — what the LLM saw
+	TraceCount  int           // size of the substrate the LLM saw
+	GeneratedAt time.Time
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -100,7 +100,7 @@ Deferred items resolved (v3.1.0, 2026-03-25): #95 `ClassifyDraftChainOptions`, #
 
 - [x] **#180 — Web UI time series controls** — `datetime-local` From/To picker; T1–T4 documented; `TestHandleShadow_WithTimeWindow` added; `time-window-controls-v1.md`
 - [x] **#181 — explore-v1.md decision record** (ANT gate) — mutable session observer, AnalysisSession design, SuggestionMeta, AnalysisTrace; `Reading` not `Result`; T172.1–T172.6; ANT gate ALIGNED
-- [ ] **#182 — AnalysisSession types + meshant explore REPL skeleton** — `explore.NewSession`; `AnalysisTurn`; cut/quit/help commands
+- [x] **#182 — AnalysisSession types + meshant explore REPL skeleton** — `meshant/explore/` package; `AnalysisSession`, `AnalysisTurn`, `SuggestionMeta`; cut/quit/help; `meshant` (no args) enters REPL; D7a amends explore-v1.md; 95.8% coverage; PR #194
 - [ ] **#183 — explore commands batch 1** — articulate, shadow, window/tag filters
 - [ ] **#184 — explore commands batch 2** — diff, gaps, follow, bottleneck
 - [ ] **#185 — suggest command with SuggestionMeta** (ANT gate) — LLM suggestions with named provenance


### PR DESCRIPTION
## Summary

- New `meshant/explore/` package: `AnalysisSession`, `AnalysisTurn`, `SuggestionMeta`, REPL loop (`Run`)
- `meshant` (no args) and `meshant <traces.json>` now enter the interactive REPL directly — no `meshant explore` subcommand
- `run()` gains `in io.Reader` parameter; dispatch propagated to all interactive subcommands
- `AnalysisTurn.Reading` (not `Result`) — naming enforces that each turn's output is a positioned act
- Per-turn snapshotting: `Observer`, `Window`, `Tags` captured at execution time; `Turns()` deep-copies `Tags`

## ANT alignment

Decision record: `docs/decisions/explore-v1.md` — ALIGNED WITH TENSIONS (T172.1–T172.6). D7a amendment documents the no-subcommand CLI change.

## Test plan

- [x] 17 black-box tests in `explore_test` (package explore_test)
- [x] 2 white-box tests in `session_internal_test.go` (Tags deep-copy, recordTurn snapshot)
- [x] 3 new/updated tests in `cmd/meshant/main_test.go` (no-args REPL, --help usage, --db+file mutual exclusion)
- [x] 95.8% coverage on `explore` package
- [x] All 13 packages pass; `go vet` clean

## Deferred

- `--analyst` flag: must be wired by #185 (suggest). TODO comment in `cmd_explore.go`.
- `tags` command and full analytical commands: #183, #184, #185, #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)