### PR TITLE
feat: explore commands batch 2 — follow, bottleneck, diff, gaps (#184)

### DIFF
--- a/meshant/explore/commands.go
+++ b/meshant/explore/commands.go
@@ -1,16 +1,19 @@
-// commands.go implements the batch-1 analytical and filter-setter commands
-// for the meshant explore REPL.
+// commands.go implements the single-observer analytical commands and filter-setter
+// commands for the meshant explore REPL.
 //
 // Commands in this file:
 //   - articulate: cuts the mesh graph from the current session position
 //   - shadow:     summarises what the current cut leaves in shadow
+//   - follow:     follows a translation chain from a named element
+//   - bottleneck: surfaces provisionally central elements
 //   - window:     sets or clears the session-level time window filter
 //   - tags:       sets or clears the session-level tag filter
 //
-// Naming note: "articulate" and "shadow" are analytical commands — they query
-// the store, produce a Reading, and record a turn. "window" and "tags" are
-// filter setters — they mutate session state that is snapshotted by subsequent
-// analytical commands, but they do not record turns themselves.
+// Dual-observer commands (diff, gaps) live in commands_dual.go.
+//
+// Shared preamble: articulateForSession performs the nil-store guard, observer
+// guard, full-substrate query, and graph.Articulate call common to all
+// single-observer analytical commands.
 //
 // See docs/decisions/explore-v1.md for the full design rationale, particularly
 // D3 (per-turn positional snapshotting) and T172.6 (live substrate).
@@ -20,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,45 +31,55 @@ import (
 	"github.com/automatedtomato/mesh-ant/meshant/store"
 )
 
+// articulateForSession performs the shared preamble for single-observer
+// analytical commands: nil-store guard, observer guard, full-substrate query,
+// and graph.Articulate with the current session cut conditions.
+//
+// Returns (graph, true, nil) on success. On guard or query failure, prints an
+// inline error to out prefixed with cmdName and returns (zero, false, nil).
+// Returns a non-nil error only for unrecoverable failures (currently none;
+// reserved for future use).
+//
+// The cmdName parameter is used to prefix inline error messages so that the
+// analyst can identify which command failed (e.g. "articulate: no trace
+// substrate loaded" vs "follow: no trace substrate loaded").
+func (s *AnalysisSession) articulateForSession(ctx context.Context, cmdName string, out io.Writer) (graph.MeshGraph, bool, error) {
+	if s.ts == nil {
+		fmt.Fprintf(out, "%s: no trace substrate loaded — open a file with: meshant <file.json>\n", cmdName)
+		return graph.MeshGraph{}, false, nil
+	}
+	if s.observer == "" {
+		fmt.Fprintf(out, "%s: observer not set — use 'cut <observer>' first\n", cmdName)
+		return graph.MeshGraph{}, false, nil
+	}
+	traces, err := s.ts.Query(ctx, store.QueryOpts{})
+	if err != nil {
+		fmt.Fprintf(out, "%s: failed to load traces: %v\n", cmdName, err)
+		return graph.MeshGraph{}, false, nil
+	}
+	g := graph.Articulate(traces, graph.ArticulationOptions{
+		ObserverPositions: []string{s.observer},
+		TimeWindow:        s.window,
+		Tags:              s.tags,
+	})
+	return g, true, nil
+}
+
 // cmdArticulate cuts the mesh graph from the current session observer position
 // and renders the result via graph.PrintArticulation.
-//
-// Guards:
-//   - s.ts == nil: inline error directing the analyst to load a file.
-//   - s.observer == "": inline error directing the analyst to use cut first.
-//   - query error: inline error; session continues.
 //
 // A turn is recorded only on success. The Reading field carries the full
 // graph.MeshGraph produced by this cut.
 func (s *AnalysisSession) cmdArticulate(ctx context.Context, rawLine string, out io.Writer) error {
-	if s.ts == nil {
-		fmt.Fprintf(out, "articulate: no trace substrate loaded — open a file with: meshant <file.json>\n")
-		return nil
+	g, ok, err := s.articulateForSession(ctx, "articulate", out)
+	if err != nil || !ok {
+		return err
 	}
-	if s.observer == "" {
-		fmt.Fprintf(out, "articulate: observer not set — use 'cut <observer>' first\n")
-		return nil
-	}
-
-	traces, err := s.ts.Query(ctx, store.QueryOpts{})
-	if err != nil {
-		fmt.Fprintf(out, "articulate: failed to load traces: %v\n", err)
-		return nil
-	}
-
-	opts := graph.ArticulationOptions{
-		ObserverPositions: []string{s.observer},
-		TimeWindow:        s.window,
-		Tags:              s.tags,
-	}
-	g := graph.Articulate(traces, opts)
-
 	// Print errors from io.Writer are terminal — the analyst cannot recover
 	// from a broken output stream.
 	if err := graph.PrintArticulation(out, g); err != nil {
 		return err
 	}
-
 	s.recordTurn(rawLine, g, nil)
 	return nil
 }
@@ -76,37 +90,77 @@ func (s *AnalysisSession) cmdArticulate(ctx context.Context, rawLine string, out
 // The shadow is not missing data — it is the structured record of what this
 // cut cannot see. The Reading field carries a graph.ShadowSummary so the
 // positional record includes what was excluded, not just what was visible.
-//
-// Guards and error handling follow the same pattern as cmdArticulate.
 func (s *AnalysisSession) cmdShadow(ctx context.Context, rawLine string, out io.Writer) error {
-	if s.ts == nil {
-		fmt.Fprintf(out, "shadow: no trace substrate loaded — open a file with: meshant <file.json>\n")
-		return nil
+	g, ok, err := s.articulateForSession(ctx, "shadow", out)
+	if err != nil || !ok {
+		return err
 	}
-	if s.observer == "" {
-		fmt.Fprintf(out, "shadow: observer not set — use 'cut <observer>' first\n")
-		return nil
-	}
-
-	traces, err := s.ts.Query(ctx, store.QueryOpts{})
-	if err != nil {
-		fmt.Fprintf(out, "shadow: failed to load traces: %v\n", err)
-		return nil
-	}
-
-	opts := graph.ArticulationOptions{
-		ObserverPositions: []string{s.observer},
-		TimeWindow:        s.window,
-		Tags:              s.tags,
-	}
-	g := graph.Articulate(traces, opts)
 	summary := graph.SummariseShadow(g)
-
 	if err := graph.PrintShadowSummary(out, summary); err != nil {
 		return err
 	}
-
 	s.recordTurn(rawLine, summary, nil)
+	return nil
+}
+
+// cmdFollow follows a translation chain from a named element through the
+// current session cut and renders the classified chain via graph.PrintChain.
+//
+// Usage: follow <element> [max_depth]
+//
+// max_depth is optional; 0 means unlimited (the graph engine default).
+// A turn is recorded only on success. The Reading field carries the
+// graph.ClassifiedChain produced by this traversal.
+func (s *AnalysisSession) cmdFollow(ctx context.Context, rawLine string, args []string, out io.Writer) error {
+	if len(args) == 0 {
+		fmt.Fprintf(out, "follow: element name required — usage: follow <element> [max_depth]\n")
+		return nil
+	}
+	element := args[0]
+
+	// Parse optional max_depth.
+	maxDepth := 0
+	if len(args) >= 2 {
+		d, err := strconv.Atoi(args[1])
+		if err != nil {
+			fmt.Fprintf(out, "follow: invalid max_depth %q: expected integer\n", args[1])
+			return nil
+		}
+		// graph.FollowOptions.MaxDepth: 0 means unlimited; negative values also satisfy
+		// MaxDepth <= 0, so they are treated identically to 0 (unlimited). No guard is
+		// needed — the behaviour is intentional and tested.
+		maxDepth = d
+	}
+
+	g, ok, err := s.articulateForSession(ctx, "follow", out)
+	if err != nil || !ok {
+		return err
+	}
+
+	chain := graph.FollowTranslation(g, element, graph.FollowOptions{MaxDepth: maxDepth})
+	cc := graph.ClassifyChain(chain, graph.ClassifyOptions{})
+	if err := graph.PrintChain(out, cc); err != nil {
+		return err
+	}
+	s.recordTurn(rawLine, cc, nil)
+	return nil
+}
+
+// cmdBottleneck identifies provisionally central elements in the current
+// session cut and renders them via graph.PrintBottleneckNotes.
+//
+// A turn is recorded only on success. The Reading field carries the
+// []graph.BottleneckNote slice produced by this analysis.
+func (s *AnalysisSession) cmdBottleneck(ctx context.Context, rawLine string, out io.Writer) error {
+	g, ok, err := s.articulateForSession(ctx, "bottleneck", out)
+	if err != nil || !ok {
+		return err
+	}
+	notes := graph.IdentifyBottlenecks(g, graph.BottleneckOptions{})
+	if err := graph.PrintBottleneckNotes(out, g, notes); err != nil {
+		return err
+	}
+	s.recordTurn(rawLine, notes, nil)
 	return nil
 }
 

--- a/meshant/explore/commands_dual.go
+++ b/meshant/explore/commands_dual.go
@@ -1,0 +1,122 @@
+// commands_dual.go implements the dual-observer analytical commands for the
+// meshant explore REPL: diff and gaps.
+//
+// Both commands compare two observer positions against the same trace substrate.
+// The current session observer (s.observer) is always position A. The second
+// observer is provided as a required argument. Both sides share the session's
+// active window and tag filters (KISS in v1; per-side overrides are deferred).
+//
+// The articulateDual helper performs the shared preamble: nil-store guard,
+// observer guard, full-substrate query, and two independent graph.Articulate
+// calls. This cannot reuse articulateForSession (which returns one graph) but
+// mirrors its contract: print inline error and return false on failure.
+//
+// See docs/decisions/explore-v1.md T172.4 for the known tension around
+// AnalysisTurn.Observer being a single string for dual-observer results.
+package explore
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/automatedtomato/mesh-ant/meshant/graph"
+	"github.com/automatedtomato/mesh-ant/meshant/store"
+)
+
+// articulateDual performs the shared preamble for dual-observer commands.
+//
+// Returns (gA, gB, true, nil) on success. On guard or query failure, prints an
+// inline error prefixed with cmdName and returns (zero, zero, false, nil).
+// Returns non-nil error only for unrecoverable failures (currently none).
+//
+// Both graphs are articulated from the same full-substrate query (D2 in
+// explore-v1.md: live substrate, not a snapshot). Both use the session's
+// current window and tags so the comparison is symmetric under the same filters.
+func (s *AnalysisSession) articulateDual(ctx context.Context, cmdName, observerB string, out io.Writer) (gA, gB graph.MeshGraph, ok bool, err error) {
+	if s.ts == nil {
+		fmt.Fprintf(out, "%s: no trace substrate loaded — open a file with: meshant <file.json>\n", cmdName)
+		return graph.MeshGraph{}, graph.MeshGraph{}, false, nil
+	}
+	if s.observer == "" {
+		fmt.Fprintf(out, "%s: observer not set — use 'cut <observer>' first\n", cmdName)
+		return graph.MeshGraph{}, graph.MeshGraph{}, false, nil
+	}
+
+	traces, qErr := s.ts.Query(ctx, store.QueryOpts{})
+	if qErr != nil {
+		fmt.Fprintf(out, "%s: failed to load traces: %v\n", cmdName, qErr)
+		return graph.MeshGraph{}, graph.MeshGraph{}, false, nil
+	}
+
+	gA = graph.Articulate(traces, graph.ArticulationOptions{
+		ObserverPositions: []string{s.observer},
+		TimeWindow:        s.window,
+		Tags:              s.tags,
+	})
+	gB = graph.Articulate(traces, graph.ArticulationOptions{
+		ObserverPositions: []string{observerB},
+		TimeWindow:        s.window,
+		Tags:              s.tags,
+	})
+	return gA, gB, true, nil
+}
+
+// cmdDiff compares the current session cut (observer A) against a second
+// observer position (observer B) and renders the positioned difference via
+// graph.PrintDiff.
+//
+// Usage: diff <observer-b>
+//
+// Both cuts share the session's active window and tag filters. The Reading
+// field carries the graph.GraphDiff produced by this comparison.
+//
+// ANT tension T172.4 (explore-v1.md): AnalysisTurn.Observer is a single string;
+// it records observer A (the session position). Observer B is carried by the
+// GraphDiff payload. A richer multi-observer turn record is deferred.
+func (s *AnalysisSession) cmdDiff(ctx context.Context, rawLine string, args []string, out io.Writer) error {
+	if len(args) == 0 {
+		fmt.Fprintf(out, "diff: observer-b required — usage: diff <observer-b>\n")
+		return nil
+	}
+
+	gA, gB, ok, err := s.articulateDual(ctx, "diff", args[0], out)
+	if err != nil || !ok {
+		return err
+	}
+
+	d := graph.Diff(gA, gB)
+	if err := graph.PrintDiff(out, d); err != nil {
+		return err
+	}
+	s.recordTurn(rawLine, d, nil)
+	return nil
+}
+
+// cmdGaps analyses what each observer can see that the other cannot, using
+// graph.AnalyseGaps on two independently articulated cuts.
+//
+// Usage: gaps <observer-b>
+//
+// Both cuts share the session's active window and tag filters. The Reading
+// field carries the graph.ObserverGap produced by this analysis.
+//
+// ANT tension T172.4 applies here too: Turn.Observer records observer A.
+func (s *AnalysisSession) cmdGaps(ctx context.Context, rawLine string, args []string, out io.Writer) error {
+	if len(args) == 0 {
+		fmt.Fprintf(out, "gaps: observer-b required — usage: gaps <observer-b>\n")
+		return nil
+	}
+
+	gA, gB, ok, err := s.articulateDual(ctx, "gaps", args[0], out)
+	if err != nil || !ok {
+		return err
+	}
+
+	gap := graph.AnalyseGaps(gA, gB)
+	if err := graph.PrintObserverGap(out, gap); err != nil {
+		return err
+	}
+	s.recordTurn(rawLine, gap, nil)
+	return nil
+}

--- a/meshant/explore/explore_test.go
+++ b/meshant/explore/explore_test.go
@@ -849,3 +849,505 @@ func TestRun_Help_ShowsNewCommands(t *testing.T) {
 		}
 	}
 }
+
+// === follow command ===
+
+func TestRun_Follow_NilStore(t *testing.T) {
+	// nil store prints inline error; no turn recorded beyond the cut.
+	s := explore.NewSession(nil, "alice")
+	out := run(t, s, "cut alice\nfollow relay-a\nquit\n")
+
+	if !strings.Contains(out, "no trace substrate") {
+		t.Errorf("expected 'no trace substrate' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Follow_NoObserver(t *testing.T) {
+	// Without a prior cut, follow prints an inline error.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "follow relay-a\nquit\n")
+
+	if !strings.Contains(out, "observer") {
+		t.Errorf("expected 'observer' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d, want 0", len(s.Turns()))
+	}
+}
+
+func TestRun_Follow_NoElement(t *testing.T) {
+	// Missing element argument prints inline error; session continues.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "cut alice\nfollow\nquit\n")
+
+	if !strings.Contains(out, "element") {
+		t.Errorf("expected 'element' in error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Follow_HappyPath(t *testing.T) {
+	// cut then follow: output contains the chain header; turn is recorded.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	out := run(t, s, "cut ops-engineer\nfollow relay\nquit\n")
+
+	if !strings.Contains(out, "=== Translation Chain (provisional reading) ===") {
+		t.Errorf("expected chain header in output, got:\n%s", out)
+	}
+	if len(s.Turns()) != 2 {
+		t.Fatalf("Turns() = %d, want 2 (cut + follow)", len(s.Turns()))
+	}
+}
+
+func TestRun_Follow_RecordsTurn(t *testing.T) {
+	// follow records a turn with the correct Command, Observer, and Reading type.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	run(t, s, "cut ops-engineer\nfollow relay\nquit\n")
+
+	turns := s.Turns()
+	if len(turns) != 2 {
+		t.Fatalf("Turns() = %d, want 2 (cut + follow)", len(turns))
+	}
+	ft := turns[1]
+	if ft.Command != "follow relay" {
+		t.Errorf("Turn.Command = %q, want %q", ft.Command, "follow relay")
+	}
+	if ft.Observer != "ops-engineer" {
+		t.Errorf("Turn.Observer = %q, want %q", ft.Observer, "ops-engineer")
+	}
+	if _, ok := ft.Reading.(graph.ClassifiedChain); !ok {
+		t.Errorf("Turn.Reading type = %T, want graph.ClassifiedChain", ft.Reading)
+	}
+}
+
+func TestRun_Follow_WithMaxDepth(t *testing.T) {
+	// follow element 2 parses max_depth=2 without error; turn recorded.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	run(t, s, "cut ops-engineer\nfollow relay 2\nquit\n")
+
+	if len(s.Turns()) != 2 {
+		t.Errorf("Turns() = %d after follow with max_depth, want 2", len(s.Turns()))
+	}
+}
+
+func TestRun_Follow_ZeroMaxDepth(t *testing.T) {
+	// follow relay 0 is valid; 0 means unlimited in the graph engine.
+	// The command should complete, produce output, and record a turn.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	out := run(t, s, "cut ops-engineer\nfollow relay 0\nquit\n")
+
+	if !strings.Contains(out, "=== Translation Chain (provisional reading) ===") {
+		t.Errorf("expected chain header in output, got:\n%s", out)
+	}
+	turns := s.Turns()
+	if len(turns) != 2 {
+		t.Fatalf("Turns() = %d, want 2 (cut + follow)", len(turns))
+	}
+	if turns[1].Command != "follow relay 0" {
+		t.Errorf("Turn.Command = %q, want %q", turns[1].Command, "follow relay 0")
+	}
+}
+
+func TestRun_Follow_NegativeMaxDepth(t *testing.T) {
+	// follow relay -1 is treated as unlimited (graph engine: MaxDepth <= 0 means unlimited).
+	// The command should complete without error and record a turn.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	out := run(t, s, "cut ops-engineer\nfollow relay -1\nquit\n")
+
+	if !strings.Contains(out, "=== Translation Chain (provisional reading) ===") {
+		t.Errorf("expected chain header for negative max_depth (treated as unlimited), got:\n%s", out)
+	}
+	if len(s.Turns()) != 2 {
+		t.Errorf("Turns() = %d, want 2 (negative max_depth treated as unlimited)", len(s.Turns()))
+	}
+}
+
+func TestRun_Follow_InvalidMaxDepth(t *testing.T) {
+	// Non-integer max_depth prints inline error; no turn beyond cut.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "cut alice\nfollow relay abc\nquit\n")
+
+	if !strings.Contains(out, "invalid") || !strings.Contains(out, "max_depth") {
+		t.Errorf("expected 'invalid max_depth' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Follow_QueryError(t *testing.T) {
+	// Store query error prints inline error; no turn beyond cut.
+	s := explore.NewSession(errStore{}, "analyst-1")
+	out := run(t, s, "cut ops-engineer\nfollow relay\nquit\n")
+
+	if !strings.Contains(out, "failed to load traces") {
+		t.Errorf("expected query error message, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+// === bottleneck command ===
+
+func TestRun_Bottleneck_NilStore(t *testing.T) {
+	// nil store prints inline error; no turn beyond cut.
+	s := explore.NewSession(nil, "alice")
+	out := run(t, s, "cut alice\nbottleneck\nquit\n")
+
+	if !strings.Contains(out, "no trace substrate") {
+		t.Errorf("expected 'no trace substrate' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Bottleneck_NoObserver(t *testing.T) {
+	// Without a prior cut, bottleneck prints an inline error.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "bottleneck\nquit\n")
+
+	if !strings.Contains(out, "observer") {
+		t.Errorf("expected 'observer' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d, want 0", len(s.Turns()))
+	}
+}
+
+func TestRun_Bottleneck_HappyPath(t *testing.T) {
+	// cut then bottleneck: output produced; turn recorded.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	out := run(t, s, "cut ops-engineer\nbottleneck\nquit\n")
+
+	// PrintBottleneckNotes always emits this exact header.
+	if !strings.Contains(out, "=== Bottleneck Notes (provisional reading from this cut) ===") {
+		t.Errorf("expected bottleneck header in output, got:\n%s", out)
+	}
+	if len(s.Turns()) != 2 {
+		t.Fatalf("Turns() = %d, want 2 (cut + bottleneck)", len(s.Turns()))
+	}
+}
+
+func TestRun_Bottleneck_RecordsTurn(t *testing.T) {
+	// bottleneck records a turn with the correct Command, Observer, Reading type.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	run(t, s, "cut ops-engineer\nbottleneck\nquit\n")
+
+	turns := s.Turns()
+	if len(turns) != 2 {
+		t.Fatalf("Turns() = %d, want 2 (cut + bottleneck)", len(turns))
+	}
+	bt := turns[1]
+	if bt.Command != "bottleneck" {
+		t.Errorf("Turn.Command = %q, want %q", bt.Command, "bottleneck")
+	}
+	if bt.Observer != "ops-engineer" {
+		t.Errorf("Turn.Observer = %q, want %q", bt.Observer, "ops-engineer")
+	}
+	if _, ok := bt.Reading.([]graph.BottleneckNote); !ok {
+		t.Errorf("Turn.Reading type = %T, want []graph.BottleneckNote", bt.Reading)
+	}
+}
+
+func TestRun_Bottleneck_EmptyStore(t *testing.T) {
+	// bottleneck against an empty store is valid: no notes; turn still recorded.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	run(t, s, "cut ops-engineer\nbottleneck\nquit\n")
+
+	turns := s.Turns()
+	if len(turns) != 2 {
+		t.Fatalf("Turns() = %d, want 2", len(turns))
+	}
+	notes, ok := turns[1].Reading.([]graph.BottleneckNote)
+	if !ok {
+		t.Fatalf("Turn.Reading type = %T, want []graph.BottleneckNote", turns[1].Reading)
+	}
+	if len(notes) != 0 {
+		t.Errorf("notes = %d for empty store, want 0", len(notes))
+	}
+}
+
+func TestRun_Bottleneck_QueryError(t *testing.T) {
+	// Store query error prints inline error; no turn beyond cut.
+	s := explore.NewSession(errStore{}, "analyst-1")
+	out := run(t, s, "cut ops-engineer\nbottleneck\nquit\n")
+
+	if !strings.Contains(out, "failed to load traces") {
+		t.Errorf("expected query error message, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+// === diff command ===
+
+func TestRun_Diff_NilStore(t *testing.T) {
+	// nil store prints inline error; no turn beyond cut.
+	s := explore.NewSession(nil, "alice")
+	out := run(t, s, "cut alice\ndiff bob\nquit\n")
+
+	if !strings.Contains(out, "no trace substrate") {
+		t.Errorf("expected 'no trace substrate' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Diff_NoObserver(t *testing.T) {
+	// Without a prior cut, diff prints an inline error.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "diff bob\nquit\n")
+
+	if !strings.Contains(out, "observer") {
+		t.Errorf("expected 'observer' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d, want 0", len(s.Turns()))
+	}
+}
+
+func TestRun_Diff_NoArg(t *testing.T) {
+	// diff without observer-b prints a usage error; no turn beyond cut.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "cut alice\ndiff\nquit\n")
+
+	if !strings.Contains(out, "observer-b") {
+		t.Errorf("expected 'observer-b' in error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Diff_HappyPath(t *testing.T) {
+	// cut obs-a then diff obs-b: output contains diff header; turn recorded.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee02", "relay B dropped packet", "security-team"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	out := run(t, s, "cut ops-engineer\ndiff security-team\nquit\n")
+
+	// PrintDiff always emits this exact header.
+	if !strings.Contains(out, "=== Mesh Diff (situated comparison) ===") {
+		t.Errorf("expected diff header in output, got:\n%s", out)
+	}
+	if len(s.Turns()) != 2 {
+		t.Fatalf("Turns() = %d, want 2 (cut + diff)", len(s.Turns()))
+	}
+}
+
+func TestRun_Diff_RecordsTurn(t *testing.T) {
+	// diff records a turn with correct Command, Observer, and Reading type.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee02", "relay B dropped packet", "security-team"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	run(t, s, "cut ops-engineer\ndiff security-team\nquit\n")
+
+	turns := s.Turns()
+	if len(turns) != 2 {
+		t.Fatalf("Turns() = %d, want 2", len(turns))
+	}
+	dt := turns[1]
+	if dt.Command != "diff security-team" {
+		t.Errorf("Turn.Command = %q, want %q", dt.Command, "diff security-team")
+	}
+	if dt.Observer != "ops-engineer" {
+		t.Errorf("Turn.Observer = %q, want %q", dt.Observer, "ops-engineer")
+	}
+	if _, ok := dt.Reading.(graph.GraphDiff); !ok {
+		t.Errorf("Turn.Reading type = %T, want graph.GraphDiff", dt.Reading)
+	}
+}
+
+func TestRun_Diff_QueryError(t *testing.T) {
+	// Store query error prints inline error; no turn beyond cut.
+	s := explore.NewSession(errStore{}, "analyst-1")
+	out := run(t, s, "cut ops-engineer\ndiff security-team\nquit\n")
+
+	if !strings.Contains(out, "failed to load traces") {
+		t.Errorf("expected query error message, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Diff_SameObserver(t *testing.T) {
+	// diff when observer A == observer B produces a zero-diff (no error).
+	// The command should complete and record a turn.
+	// Note: a same-observer guard ("diff: observer-b must differ") is deferred to v2.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	out := run(t, s, "cut ops-engineer\ndiff ops-engineer\nquit\n")
+
+	if !strings.Contains(out, "=== Mesh Diff (situated comparison) ===") {
+		t.Errorf("expected diff header even for same-observer diff, got:\n%s", out)
+	}
+	if len(s.Turns()) != 2 {
+		t.Errorf("Turns() = %d, want 2 (cut + diff)", len(s.Turns()))
+	}
+}
+
+// === gaps command ===
+
+func TestRun_Gaps_NilStore(t *testing.T) {
+	// nil store prints inline error; no turn beyond cut.
+	s := explore.NewSession(nil, "alice")
+	out := run(t, s, "cut alice\ngaps bob\nquit\n")
+
+	if !strings.Contains(out, "no trace substrate") {
+		t.Errorf("expected 'no trace substrate' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Gaps_NoObserver(t *testing.T) {
+	// Without a prior cut, gaps prints an inline error.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "gaps bob\nquit\n")
+
+	if !strings.Contains(out, "observer") {
+		t.Errorf("expected 'observer' error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 0 {
+		t.Errorf("Turns() = %d, want 0", len(s.Turns()))
+	}
+}
+
+func TestRun_Gaps_NoArg(t *testing.T) {
+	// gaps without observer-b prints a usage error; no turn beyond cut.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "cut alice\ngaps\nquit\n")
+
+	if !strings.Contains(out, "observer-b") {
+		t.Errorf("expected 'observer-b' in error, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Gaps_HappyPath(t *testing.T) {
+	// cut obs-a then gaps obs-b: output contains gap analysis; turn recorded.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee02", "relay B dropped packet", "security-team"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	out := run(t, s, "cut ops-engineer\ngaps security-team\nquit\n")
+
+	// PrintObserverGap always emits this exact header.
+	if !strings.Contains(out, "=== Observer Gap ===") {
+		t.Errorf("expected gap header in output, got:\n%s", out)
+	}
+	if len(s.Turns()) != 2 {
+		t.Fatalf("Turns() = %d, want 2 (cut + gaps)", len(s.Turns()))
+	}
+}
+
+func TestRun_Gaps_RecordsTurn(t *testing.T) {
+	// gaps records a turn with correct Command, Observer, and Reading type.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee02", "relay B dropped packet", "security-team"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	run(t, s, "cut ops-engineer\ngaps security-team\nquit\n")
+
+	turns := s.Turns()
+	if len(turns) != 2 {
+		t.Fatalf("Turns() = %d, want 2", len(turns))
+	}
+	gt := turns[1]
+	if gt.Command != "gaps security-team" {
+		t.Errorf("Turn.Command = %q, want %q", gt.Command, "gaps security-team")
+	}
+	if gt.Observer != "ops-engineer" {
+		t.Errorf("Turn.Observer = %q, want %q", gt.Observer, "ops-engineer")
+	}
+	if _, ok := gt.Reading.(graph.ObserverGap); !ok {
+		t.Errorf("Turn.Reading type = %T, want graph.ObserverGap", gt.Reading)
+	}
+}
+
+func TestRun_Gaps_QueryError(t *testing.T) {
+	// Store query error prints inline error; no turn beyond cut.
+	s := explore.NewSession(errStore{}, "analyst-1")
+	out := run(t, s, "cut ops-engineer\ngaps security-team\nquit\n")
+
+	if !strings.Contains(out, "failed to load traces") {
+		t.Errorf("expected query error message, got:\n%s", out)
+	}
+	if len(s.Turns()) != 1 {
+		t.Errorf("Turns() = %d, want 1 (only the cut)", len(s.Turns()))
+	}
+}
+
+func TestRun_Gaps_SameObserver(t *testing.T) {
+	// gaps when observer A == observer B produces an empty-gap result (no error).
+	// The command should complete and record a turn.
+	// Note: a same-observer guard is deferred to v2.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1")
+	out := run(t, s, "cut ops-engineer\ngaps ops-engineer\nquit\n")
+
+	if !strings.Contains(out, "=== Observer Gap ===") {
+		t.Errorf("expected gap header even for same-observer gaps, got:\n%s", out)
+	}
+	if len(s.Turns()) != 2 {
+		t.Errorf("Turns() = %d, want 2 (cut + gaps)", len(s.Turns()))
+	}
+}
+
+// === help — batch 2 commands ===
+
+func TestRun_Help_ShowsBatch2Commands(t *testing.T) {
+	// help output lists all batch-2 commands.
+	s := explore.NewSession(testStore(t), "analyst-1")
+	out := run(t, s, "help\nquit\n")
+
+	for _, keyword := range []string{"diff", "gaps", "follow", "bottleneck"} {
+		if !strings.Contains(out, keyword) {
+			t.Errorf("help output missing %q\nfull output:\n%s", keyword, out)
+		}
+	}
+}

--- a/meshant/explore/session.go
+++ b/meshant/explore/session.go
@@ -152,6 +152,14 @@ func (s *AnalysisSession) dispatch(ctx context.Context, line string, out io.Writ
 		return s.cmdArticulate(ctx, line, out)
 	case "shadow":
 		return s.cmdShadow(ctx, line, out)
+	case "follow":
+		return s.cmdFollow(ctx, line, args, out)
+	case "bottleneck":
+		return s.cmdBottleneck(ctx, line, out)
+	case "diff":
+		return s.cmdDiff(ctx, line, args, out)
+	case "gaps":
+		return s.cmdGaps(ctx, line, args, out)
 	case "window":
 		return s.cmdWindow(line, args, out)
 	case "tags":
@@ -186,12 +194,16 @@ func (s *AnalysisSession) cmdCut(rawLine string, args []string, out io.Writer) e
 }
 
 // helpText returns the help listing for the current command set.
-// Extended in #184–#186 as new commands are added.
+// Extended in #185–#186 as new commands are added.
 func helpText() string {
 	return `Commands:
   cut <observer>           set the observer position for subsequent turns
   articulate               articulate the mesh graph from the current position
   shadow                   summarise what the current cut leaves in shadow
+  diff <observer-b>        compare current cut against observer-b's reading
+  gaps <observer-b>        analyse what each observer sees that the other does not
+  follow <element> [depth] follow a translation chain from the named element
+  bottleneck               surface provisionally central elements in the current cut
   window <from> <to>       set a time window filter (RFC3339); 'window clear' to reset
   tags <t1> [t2...]        set tag filters; 'tags clear' to reset
   help  (h)                show this help

--- a/meshant/explore/turn.go
+++ b/meshant/explore/turn.go
@@ -30,10 +30,10 @@ import (
 //   - cut:         nil (cut changes state; it is not itself a mesh reading)
 //   - articulate:  graph.MeshGraph
 //   - shadow:      graph.ShadowSummary
-//   - follow:      graph.TranslationChain
-//   - bottleneck:  []graph.BottleneckElement
+//   - follow:      graph.ClassifiedChain
+//   - bottleneck:  []graph.BottleneckNote
 //   - diff:        graph.GraphDiff
-//   - gaps:        graph.GapsResult
+//   - gaps:        graph.ObserverGap
 //   - summarize:   string
 //   - validate:    string
 //   - help:        string


### PR DESCRIPTION
## What changed

Implements the second batch of analytical commands for the `meshant explore` REPL (issue #184), completing the analytical command set for v1.

### Single-observer commands (`commands.go`)

- **`articulateForSession`** — extracted shared preamble (nil-store guard, observer guard, full-substrate query, `graph.Articulate` call) used by all four single-observer commands. Returns `(MeshGraph, bool, error)` — `bool` distinguishes "inline error already printed" from "unrecoverable error".
- **`cmdFollow`** — follows a translation chain via `graph.FollowTranslation` + `graph.ClassifyChain` + `graph.PrintChain`. Optional `max_depth` arg; 0/negative treated as unlimited per `graph.FollowOptions` contract (documented in comment).
- **`cmdBottleneck`** — surfaces provisionally central elements via `graph.IdentifyBottlenecks` + `graph.PrintBottleneckNotes`.
- **`cmdArticulate` / `cmdShadow`** — refactored to use `articulateForSession`.

### Dual-observer commands (`commands_dual.go`, new file)

- **`articulateDual`** — shared preamble: single store query, two independent `graph.Articulate` calls with the same window/tags (symmetric comparison, KISS, per-side overrides deferred).
- **`cmdDiff`** — positioned comparison via `graph.Diff` + `graph.PrintDiff`.
- **`cmdGaps`** — gap analysis via `graph.AnalyseGaps` + `graph.PrintObserverGap`.

ANT tension T172.4 (`AnalysisTurn.Observer` is a single string for dual-observer results) acknowledged in both command doc comments and in `explore-v1.md`.

### Supporting changes

- `session.go` — 4 new dispatch cases; `helpText()` updated.
- `turn.go` — 3 type comment fixes (`ClassifiedChain`, `[]BottleneckNote`, `ObserverGap`).

## Why

Completes the analytical command surface scoped in `docs/decisions/explore-v1.md`. Single-observer commands reuse `articulateForSession` to eliminate repeated guard/query boilerplate. Dual-observer commands live in their own file because their shape (one query, two Articulate calls) is genuinely different from the single-observer preamble.

## Testing

- ~30 new tests; **95.5% coverage**
- All error paths covered for every new command (nil store, no observer, missing arg, query error, invalid arg)
- Happy-path tests assert specific header strings emitted by `Print*` functions (not weak OR assertions)
- `TestRun_Follow_ZeroMaxDepth`, `TestRun_Follow_NegativeMaxDepth` — edge cases for `max_depth`
- `TestRun_Diff_SameObserver`, `TestRun_Gaps_SameObserver` — same-observer guard deferred to v2; behavior confirmed as valid (zero-diff / empty-gap)

## Reviews

- Code reviewer: APPROVE (4 LOW items addressed)
- ANT theorist: ALIGNED — no violations
- QA engineer: PASS after fixes (4 required items addressed: header assertions, ZeroMaxDepth, NegativeMaxDepth, SameObserver tests)
- Architect: APPROVED

## Trade-offs

- Same-observer guard (`diff alice` when observer A is already `alice`) is deferred — the engine produces a zero-diff, which is valid. Guard documented as v2 follow-up.
- Per-side filter overrides for `diff`/`gaps` deferred (KISS in v1; documented in `commands_dual.go` and `explore-v1.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)