### PR TITLE
chore: add prompt-content assertions for suggest command tests (#198)

### DIFF
--- a/meshant/explore/explore_test.go
+++ b/meshant/explore/explore_test.go
@@ -1502,6 +1502,53 @@ func TestRun_Suggest_HappyPath(t *testing.T) {
 	if st.Suggestion.GeneratedAt.IsZero() {
 		t.Error("Suggestion.GeneratedAt is zero")
 	}
+	// Verify the LLM was actually called (not silently skipped).
+	if mc.callCount != 1 {
+		t.Errorf("LLM callCount = %d, want 1", mc.callCount)
+	}
+}
+
+func TestRun_Suggest_PromptContent(t *testing.T) {
+	// Verifies the observable contract of buildSuggestPrompt:
+	// the observer position, the basis label, and a non-empty system prompt
+	// must be sent to the LLM. A regression that sends blank or wrong context
+	// would be caught here.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	mc := &mockSuggestClient{response: "Navigate the network"}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1", mc)
+	run(t, s, "cut ops-engineer\nshadow\nsuggest\nquit\n")
+
+	// System prompt must be non-empty (the ANT framing was sent).
+	if mc.lastSystem == "" {
+		t.Error("lastSystem is empty — system prompt was not sent to LLM")
+	}
+	// User prompt must contain the observer position.
+	if !strings.Contains(mc.lastPrompt, "ops-engineer") {
+		t.Errorf("lastPrompt does not contain observer %q\nprompt:\n%s", "ops-engineer", mc.lastPrompt)
+	}
+	// User prompt must contain the basis label.
+	if !strings.Contains(mc.lastPrompt, "shadow") {
+		t.Errorf("lastPrompt does not contain basis label %q\nprompt:\n%s", "shadow", mc.lastPrompt)
+	}
+}
+
+func TestRun_Suggest_PromptContent_Bottleneck(t *testing.T) {
+	// Verify prompt content when basis is bottleneck.
+	traces := []schema.Trace{
+		newValidTrace("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01", "relay A routed packet", "ops-engineer"),
+	}
+	mc := &mockSuggestClient{response: "Relay is central"}
+	s := explore.NewSession(testStoreWithTraces(t, traces), "analyst-1", mc)
+	run(t, s, "cut ops-engineer\nbottleneck\nsuggest\nquit\n")
+
+	if !strings.Contains(mc.lastPrompt, "ops-engineer") {
+		t.Errorf("lastPrompt missing observer %q\nprompt:\n%s", "ops-engineer", mc.lastPrompt)
+	}
+	if !strings.Contains(mc.lastPrompt, "bottleneck") {
+		t.Errorf("lastPrompt missing basis label %q\nprompt:\n%s", "bottleneck", mc.lastPrompt)
+	}
 }
 
 func TestRun_Suggest_ExplicitBasis_Shadow(t *testing.T) {


### PR DESCRIPTION
## What

Test-only cleanup addressing post-merge QA findings from #185 (PR #197).

**Finding 1**: `mockSuggestClient.lastSystem`/`lastPrompt` were captured on every `Complete` call but never read by any test. `buildSuggestPrompt`'s observable contract — that the observer position, basis label, and system prompt are correctly sent to the LLM — was entirely unverified.

**Finding 8**: The dead fields in the mock would confuse future maintainers who assume they are used for assertions.

## Changes (`explore_test.go` only)

- `TestRun_Suggest_PromptContent` — asserts `lastSystem` non-empty, `lastPrompt` contains observer string and `"shadow"` basis label
- `TestRun_Suggest_PromptContent_Bottleneck` — same contract for bottleneck basis
- `TestRun_Suggest_HappyPath` — adds `mc.callCount == 1` assertion (LLM called exactly once on success)

No implementation changes.

## Why a separate issue/PR

Arrived as a post-merge QA finding after #185 was already in `develop`. Kept as a chore branch per the detour-issue workflow to maintain visible GitHub history.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)