### PR TITLE
feat: AnalysisTrace + TagValueExplore + promote-explore (#186)

### DIFF
--- a/meshant/explore/explore_test.go
+++ b/meshant/explore/explore_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1744,5 +1745,269 @@ func TestRun_Help_ShowsSuggest(t *testing.T) {
 
 	if !strings.Contains(out, "suggest") {
 		t.Errorf("help output missing 'suggest'\nfull output:\n%s", out)
+	}
+}
+
+func TestRun_Help_ShowsSave(t *testing.T) {
+	s := explore.NewSession(testStore(t), "analyst-1", nil)
+	out := run(t, s, "help\nquit\n")
+
+	if !strings.Contains(out, "save") {
+		t.Errorf("help output missing 'save'\nfull output:\n%s", out)
+	}
+}
+
+// === save command / Promote ===
+
+// TestRun_Save_NoStore verifies that save refuses gracefully when no store is
+// configured. The session continues after the inline error.
+func TestRun_Save_NoStore(t *testing.T) {
+	s := explore.NewSession(nil, "analyst-1", nil)
+	out := run(t, s, "save\nquit\n")
+
+	if !strings.Contains(out, "no store") {
+		t.Errorf("save with nil store should mention 'no store', got:\n%s", out)
+	}
+}
+
+// TestRun_Save_NoAnalyst verifies that save refuses when the session has no
+// analyst name — an unattributable promotion.
+func TestRun_Save_NoAnalyst(t *testing.T) {
+	ts := testStore(t)
+	s := explore.NewSession(ts, "", nil)
+	out := run(t, s, "save\nquit\n")
+
+	if !strings.Contains(out, "analyst") {
+		t.Errorf("save without analyst should mention 'analyst', got:\n%s", out)
+	}
+}
+
+// TestRun_Save_NoTurns verifies that a session with no analytical turns can
+// still be promoted — it is a valid (empty) observation act.
+func TestRun_Save_NoTurns(t *testing.T) {
+	ts := testStore(t)
+	s := explore.NewSession(ts, "analyst-1", nil)
+	out := run(t, s, "save\nquit\n")
+
+	if !strings.Contains(out, "promoted") {
+		t.Errorf("save should print confirmation, got:\n%s", out)
+	}
+
+	// Verify the promoted trace exists in the store.
+	traces, err := ts.Query(context.Background(), store.QueryOpts{Tags: []string{string(explore.TagValueExplore)}})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("want 1 promoted trace, got %d", len(traces))
+	}
+
+	tr := traces[0]
+	if tr.Observer != "analyst-1" {
+		t.Errorf("promoted trace Observer = %q, want %q", tr.Observer, "analyst-1")
+	}
+	if tr.Mediation != "meshant explore" {
+		t.Errorf("promoted trace Mediation = %q, want %q", tr.Mediation, "meshant explore")
+	}
+	if !strings.Contains(tr.WhatChanged, "0 turns") {
+		t.Errorf("promoted trace WhatChanged should contain '0 turns', got %q", tr.WhatChanged)
+	}
+	if len(tr.Source) != 0 {
+		t.Errorf("promoted trace Source should be empty for no-turn session, got %v", tr.Source)
+	}
+	if len(tr.Target) != 0 {
+		t.Errorf("promoted trace Target should be empty for no-turn session, got %v", tr.Target)
+	}
+}
+
+// TestRun_Save_HappyPath verifies that a session with multiple observers and
+// turns is promoted with the correct field values.
+func TestRun_Save_HappyPath(t *testing.T) {
+	traces := []schema.Trace{
+		newValidTrace("00000000-0000-0000-0000-000000000001", "alpha changed", "alice"),
+		newValidTrace("00000000-0000-0000-0000-000000000002", "beta changed", "alice"),
+		newValidTrace("00000000-0000-0000-0000-000000000003", "gamma changed", "bob"),
+	}
+	ts := testStoreWithTraces(t, traces)
+	s := explore.NewSession(ts, "lead-analyst", nil)
+
+	// 4 analytical turns: cut alice, cut bob (each records a turn), then save.
+	out := run(t, s, "cut alice\ncut bob\nsave\nquit\n")
+
+	if !strings.Contains(out, "promoted") {
+		t.Errorf("save should print confirmation, got:\n%s", out)
+	}
+
+	promoted, err := ts.Query(context.Background(), store.QueryOpts{Tags: []string{string(explore.TagValueExplore)}})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(promoted) != 1 {
+		t.Fatalf("want 1 promoted trace, got %d", len(promoted))
+	}
+
+	tr := promoted[0]
+	if tr.Observer != "lead-analyst" {
+		t.Errorf("Observer = %q, want %q", tr.Observer, "lead-analyst")
+	}
+	if tr.Mediation != "meshant explore" {
+		t.Errorf("Mediation = %q, want %q", tr.Mediation, "meshant explore")
+	}
+	if !strings.Contains(tr.WhatChanged, "alice") {
+		t.Errorf("WhatChanged should contain 'alice', got %q", tr.WhatChanged)
+	}
+	if !strings.Contains(tr.WhatChanged, "bob") {
+		t.Errorf("WhatChanged should contain 'bob', got %q", tr.WhatChanged)
+	}
+	// Source should contain both observers in first-appearance order.
+	wantSource := []string{"alice", "bob"}
+	if !reflect.DeepEqual(tr.Source, wantSource) {
+		t.Errorf("Source = %v, want %v", tr.Source, wantSource)
+	}
+	// TagValueExplore must be present.
+	found := false
+	for _, tag := range tr.Tags {
+		if tag == string(explore.TagValueExplore) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Tags = %v, want to contain %q", tr.Tags, string(explore.TagValueExplore))
+	}
+}
+
+// TestRun_Save_FinalTarget verifies that the promoted trace carries the element
+// names from the final articulation turn in its Target field.
+func TestRun_Save_FinalTarget(t *testing.T) {
+	traces := []schema.Trace{
+		{
+			ID:          "00000000-0000-0000-0000-000000000001",
+			Timestamp:   baseTime,
+			WhatChanged: "link formed",
+			Observer:    "alice",
+			Source:      []string{"actor-x"},
+			Target:      []string{"actor-y"},
+		},
+	}
+	ts := testStoreWithTraces(t, traces)
+	s := explore.NewSession(ts, "analyst-1", nil)
+
+	run(t, s, "cut alice\narticulate\nsave\nquit\n")
+
+	promoted, err := ts.Query(context.Background(), store.QueryOpts{Tags: []string{string(explore.TagValueExplore)}})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(promoted) != 1 {
+		t.Fatalf("want 1 promoted trace, got %d", len(promoted))
+	}
+
+	tr := promoted[0]
+	// Target should contain the element names from the articulation (actor-x and actor-y).
+	targetSet := make(map[string]bool, len(tr.Target))
+	for _, elem := range tr.Target {
+		targetSet[elem] = true
+	}
+	for _, want := range []string{"actor-x", "actor-y"} {
+		if !targetSet[want] {
+			t.Errorf("Target %v missing element %q from final articulation", tr.Target, want)
+		}
+	}
+}
+
+// TestRun_Save_ObserverDedup verifies that visiting the same observer position
+// multiple times yields a single Source entry for that position.
+func TestRun_Save_ObserverDedup(t *testing.T) {
+	ts := testStore(t)
+	s := explore.NewSession(ts, "analyst-1", nil)
+
+	// alice visited twice — should appear once in Source.
+	run(t, s, "cut alice\ncut alice\nsave\nquit\n")
+
+	promoted, err := ts.Query(context.Background(), store.QueryOpts{Tags: []string{string(explore.TagValueExplore)}})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(promoted) != 1 {
+		t.Fatalf("want 1 promoted trace, got %d", len(promoted))
+	}
+
+	tr := promoted[0]
+	aliceCount := 0
+	for _, s := range tr.Source {
+		if s == "alice" {
+			aliceCount++
+		}
+	}
+	if aliceCount != 1 {
+		t.Errorf("Source %v: alice appears %d times, want exactly 1", tr.Source, aliceCount)
+	}
+}
+
+// TestPromote_EmptySession verifies that Promote() called directly with no
+// turns produces a valid trace with 0 turns and empty Source/Target.
+func TestPromote_EmptySession(t *testing.T) {
+	ts := testStore(t)
+	s := explore.NewSession(ts, "analyst-1", nil)
+
+	if err := s.Promote(context.Background()); err != nil {
+		t.Fatalf("Promote() unexpected error: %v", err)
+	}
+
+	promoted, err := ts.Query(context.Background(), store.QueryOpts{Tags: []string{string(explore.TagValueExplore)}})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(promoted) != 1 {
+		t.Fatalf("want 1 promoted trace, got %d", len(promoted))
+	}
+
+	tr := promoted[0]
+	if tr.Observer != "analyst-1" {
+		t.Errorf("Observer = %q, want %q", tr.Observer, "analyst-1")
+	}
+	if !strings.Contains(tr.WhatChanged, "0 turns") {
+		t.Errorf("WhatChanged should contain '0 turns', got %q", tr.WhatChanged)
+	}
+	if len(tr.Source) != 0 {
+		t.Errorf("Source should be nil for empty session, got %v", tr.Source)
+	}
+	if len(tr.Target) != 0 {
+		t.Errorf("Target should be nil for empty session, got %v", tr.Target)
+	}
+}
+
+// TestRun_Save_CalledTwice verifies that calling save twice on the same session
+// produces two independent explore traces — each a snapshot of the session state
+// at the time of that save. This supports mid-session saves (D5 in explore-v1.md:
+// "`save` is callable mid-session (a partial record) or at the end").
+//
+// The two traces have different IDs (new UUID per Promote call) and are
+// stored as independent entries — not updates to a prior record.
+func TestRun_Save_CalledTwice(t *testing.T) {
+	ts := testStore(t)
+	s := explore.NewSession(ts, "analyst-1", nil)
+
+	// First save: 1 turn (the cut).
+	out := run(t, s, "cut alice\nsave\ncut bob\nsave\nquit\n")
+
+	// Both saves should report success.
+	if strings.Count(out, "session promoted") != 2 {
+		t.Errorf("expected 2 'session promoted' messages, got:\n%s", out)
+	}
+
+	// Two independent explore traces should be in the store.
+	promoted, err := ts.Query(context.Background(), store.QueryOpts{Tags: []string{string(explore.TagValueExplore)}})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(promoted) != 2 {
+		t.Fatalf("want 2 promoted traces (one per save), got %d", len(promoted))
+	}
+
+	// IDs must be distinct — each Promote call generates a new UUID.
+	if promoted[0].ID == promoted[1].ID {
+		t.Errorf("promoted traces share ID %q — expected distinct UUIDs", promoted[0].ID)
 	}
 }

--- a/meshant/explore/session.go
+++ b/meshant/explore/session.go
@@ -171,6 +171,8 @@ func (s *AnalysisSession) dispatch(ctx context.Context, line string, out io.Writ
 		return s.cmdGaps(ctx, line, args, out)
 	case "suggest":
 		return s.cmdSuggest(ctx, line, args, out)
+	case "save":
+		return s.cmdSave(ctx, line, out)
 	case "window":
 		return s.cmdWindow(line, args, out)
 	case "tags":
@@ -216,10 +218,11 @@ func helpText() string {
   follow <element> [depth]      follow a translation chain from the named element
   bottleneck                    surface provisionally central elements in the current cut
   suggest [shadow|bottleneck|gaps]  LLM navigational suggestion from a prior reading
+  save                          promote this session to the TraceStore as an explore trace
   window <from> <to>            set a time window filter (RFC3339); 'window clear' to reset
   tags <t1> [t2...]             set tag filters; 'tags clear' to reset
   help  (h)                     show this help
-  quit  (q)                     end the session; discards unsaved turns
+  quit  (q)                     end the session; unsaved sessions are discarded
 `
 }
 

--- a/meshant/explore/trace.go
+++ b/meshant/explore/trace.go
@@ -1,0 +1,201 @@
+// trace.go implements Principle 8 reflexivity for the meshant explore REPL.
+//
+// A completed analysis session can be promoted to the TraceStore via the `save`
+// command. The promoted record is a single schema.Trace that captures the
+// analytical trajectory — the sequence of observer positions visited and the
+// element set visible in the final articulation.
+//
+// This closes the reflexivity gap: the interactive analysis apparatus enters the
+// mesh it analyzed. The session was a positioned observation act; it now appears
+// in the same substrate as the traces it read.
+//
+// Multiple saves are permitted: each call to save/Promote records the session
+// state at that moment. This supports mid-session promotion (a partial record)
+// as well as final promotion. Each promoted trace receives a new UUID, so they
+// are independent entries in the store — not updates to a prior record.
+//
+// Design: D5 in docs/decisions/explore-v1.md.
+// Tensions: T172.1 (acts, not readings) and T172.5 (positions as Source).
+package explore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/automatedtomato/mesh-ant/meshant/graph"
+	"github.com/automatedtomato/mesh-ant/meshant/loader"
+	"github.com/automatedtomato/mesh-ant/meshant/schema"
+)
+
+// TagValueExplore marks a trace promoted from an interactive explore session.
+//
+// Distinct from schema.TagValueSession ("session"), which marks LLM session
+// promotions. An explore session is a human-driven analytical act; an LLM
+// session is a machine-driven extraction act.
+//
+// Typed as schema.TagValue for consistency with the schema tag vocabulary
+// (TagValueSession, TagValueArticulation, TagValueDraft).
+const TagValueExplore schema.TagValue = "explore"
+
+// Promote converts the analysis session into a schema.Trace and stores it,
+// closing the Principle 8 reflexivity gap: the explore session — itself an
+// observation act — enters the mesh as a trace.
+//
+// Multiple calls are permitted — see package doc and D5 in explore-v1.md.
+// Each call promotes the session state at that moment with a new UUID.
+// This supports mid-session saves (partial records) as well as final saves.
+//
+// Guards (return error; session state is not modified):
+//  1. ts is nil — no store to write to
+//  2. s.analyst is empty — unattributable observation (who conducted the session?)
+//
+// Field mapping:
+//
+//	ID          ← new UUID v4 (unique per Promote call)
+//	Timestamp   ← time.Now()
+//	Observer    ← s.analyst (who conducted the session)
+//	WhatChanged ← "explore session: N turns, observers visited: [alice, bob, ...]"
+//	Mediation   ← "meshant explore"
+//	Source      ← deduplicated observer positions in order of first appearance
+//	             (T172.5: these are reading positions, not network elements — named, not resolved)
+//	Target      ← element names from the final articulation turn's MeshGraph.Nodes;
+//	             nil if no articulation turn exists, []string{} if articulation produced an empty graph
+//	             (T172.1: final reading, not a full trajectory snapshot — named, not resolved)
+//	Tags        ← [TagValueExplore]
+func (s *AnalysisSession) Promote(ctx context.Context) error {
+	if s.ts == nil {
+		return errors.New("save: no store — load a trace file or connect a database first")
+	}
+	if s.analyst == "" {
+		return errors.New("save: analyst name required — cannot promote an unattributable session (use --analyst flag)")
+	}
+
+	id, err := loader.NewUUID()
+	if err != nil {
+		return fmt.Errorf("save: generate UUID: %w", err)
+	}
+
+	observers := observerPositions(s.turns)
+	target := finalArticulationElements(s.turns)
+	whatChanged := exploreWhatChanged(len(s.turns), observers)
+
+	t := schema.Trace{
+		ID:          id,
+		Timestamp:   time.Now(),
+		Observer:    s.analyst,
+		WhatChanged: whatChanged,
+		Mediation:   "meshant explore",
+		Source:      observers,
+		Target:      target,
+		Tags:        []string{string(TagValueExplore)},
+	}
+
+	if err := t.Validate(); err != nil {
+		return fmt.Errorf("save: promoted trace invalid: %w", err)
+	}
+
+	if err := s.ts.Store(ctx, []schema.Trace{t}); err != nil {
+		return fmt.Errorf("save: store failed: %w", err)
+	}
+
+	return nil
+}
+
+// cmdSave handles the "save" REPL command: promotes the current session to the
+// TraceStore as a schema.Trace tagged TagValueExplore.
+//
+// Multiple saves are permitted — each records the session state at that moment.
+// Errors are printed inline — the session continues after a failed save so
+// the analyst can correct the issue (e.g. set an analyst name) without losing
+// their session state.
+//
+// The rawLine parameter is unused: cmdSave does not record a turn because
+// saving is a meta-operation that records the session, not an analytical act
+// that produces a positioned reading.
+func (s *AnalysisSession) cmdSave(ctx context.Context, _ string, out io.Writer) error {
+	if err := s.Promote(ctx); err != nil {
+		fmt.Fprintf(out, "%v\n", err)
+		return nil
+	}
+	fmt.Fprintf(out, "session promoted: %d turns recorded as explore trace\n", len(s.turns))
+	return nil
+}
+
+// observerPositions extracts deduplicated observer positions from the turn
+// history in order of first appearance.
+//
+// Empty observer values are skipped — they arise when a turn is recorded before
+// the first `cut` command sets s.observer (e.g. if a future command calls
+// recordTurn while s.observer is still ""). An empty string is not a valid
+// reading position in the promoted trace's Source.
+//
+// Returns nil when no observer was ever set (valid; the promoted Source is nil).
+//
+// T172.5 tension: observer positions are analytical reading positions, not network
+// elements. Placing them in Source conflates "which position the analyst read from"
+// with "what produced the trace." This encoding is provisional — see explore-v1.md
+// T172.5. The TagValueExplore tag signals that Source/Target should be interpreted
+// differently for explore-promoted traces.
+func observerPositions(turns []AnalysisTurn) []string {
+	seen := make(map[string]bool)
+	var positions []string
+	for _, t := range turns {
+		if t.Observer == "" || seen[t.Observer] {
+			continue
+		}
+		seen[t.Observer] = true
+		positions = append(positions, t.Observer)
+	}
+	return positions
+}
+
+// finalArticulationElements returns the sorted element names from the last turn
+// whose Reading is a graph.MeshGraph (i.e. the last `articulate` command).
+//
+// Returns:
+//   - nil        — no articulation turn exists in the session history
+//   - []string{} — articulation ran but the graph was empty (no traces matched the cut)
+//   - []string{...} — sorted element names from the final articulation's Nodes map
+//
+// The nil/empty distinction preserves the difference between "analyst never
+// articulated" and "analyst articulated but the cut found nothing." Both are
+// valid and analytically meaningful states. Downstream consumers can read
+// nil Target as "no articulation performed" and len(Target)==0 as "articulation
+// returned an empty graph."
+//
+// T172.1 tension: this records the elements visible in the final reading, not a
+// snapshot of the full analytical trajectory across all turns. Named, not resolved.
+func finalArticulationElements(turns []AnalysisTurn) []string {
+	for i := len(turns) - 1; i >= 0; i-- {
+		g, ok := turns[i].Reading.(graph.MeshGraph)
+		if !ok {
+			continue
+		}
+		if len(g.Nodes) == 0 {
+			// Articulation ran; graph was empty. Return non-nil empty slice to
+			// distinguish from the "no articulation turn" case (which returns nil).
+			return []string{}
+		}
+		names := make([]string, 0, len(g.Nodes))
+		for name := range g.Nodes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return names
+	}
+	return nil
+}
+
+// exploreWhatChanged generates the WhatChanged string for a promoted explore trace.
+//
+// Example output: "explore session: 5 turns, observers visited: [alice, bob]"
+// With no observers: "explore session: 0 turns, observers visited: []"
+func exploreWhatChanged(turnCount int, observers []string) string {
+	return fmt.Sprintf("explore session: %d turns, observers visited: [%s]",
+		turnCount, strings.Join(observers, ", "))
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -104,7 +104,7 @@ Deferred items resolved (v3.1.0, 2026-03-25): #95 `ClassifyDraftChainOptions`, #
 - [x] **#183 — explore commands batch 1** — articulate, shadow, window/tag filters; `commands.go`; errStore stub; 96.6% coverage; PR #195
 - [x] **#184 — explore commands batch 2** — follow, bottleneck, diff, gaps; `commands_dual.go` new file; `articulateForSession`/`articulateDual` helpers; 95.5% coverage; PR #196
 - [x] **#185 — suggest command with SuggestionMeta** — `suggest.go` new file; `SuggestClient` interface; 5 guards; basis auto-detect (shadow/bottleneck/gaps); `--analyst` flag wired; 94.8% coverage; PR #197
-- [ ] **#186 — AnalysisTrace + TagValueExplore + promote-explore** (ANT gate) — Principle 8 reflexivity for explore sessions
+- [x] **#186 — AnalysisTrace + TagValueExplore + promote-explore** (ANT gate) — `trace.go` new file; `TagValueExplore schema.TagValue`; `Promote(ctx)`; `save` command; `observerPositions`/`finalArticulationElements`; nil/empty/populated Target distinction; multiple saves produce independent traces; 9 tests; 94.2% coverage; PR #200
 
 ### v5.0.0 — Actors Act (parent: #173)
 


### PR DESCRIPTION
## Summary

- New `trace.go`: `TagValueExplore` constant, `Promote(ctx)` method on `*AnalysisSession`, `save` REPL command, and three helper functions
- `Promote` builds a `schema.Trace` from the session state (analyst, observer positions visited, final articulation elements) and stores it — closing the Principle 8 reflexivity gap
- Multiple saves are permitted: each snapshots the current session state with a new UUID, supporting mid-session partial records (D5 in `explore-v1.md`)
- `TagValueExplore schema.TagValue = "explore"` typed consistently with `TagValueSession`, `TagValueDraft`, `TagValueArticulation`

## Field mapping (D5)

| Field | Value |
|-------|-------|
| Observer | `s.analyst` — session conductor |
| Source | deduplicated observer positions, first-appearance order (T172.5: reading positions, not network elements — named, not resolved) |
| Target | elements from final `graph.MeshGraph` articulation; `nil`=no articulation, `[]string{}`=empty graph, `[...]`=elements (T172.1 named) |
| Mediation | `"meshant explore"` |
| Tags | `[TagValueExplore]` |

## Review pipeline

- ANT theorist: **ALIGNED WITH TENSIONS** — T172.1 and T172.5 correctly named; language disciplined; `TagValueExplore` now typed as `schema.TagValue`
- Code reviewer: HIGH-1 (multiple saves ambiguity) and HIGH-2 (no double-save test) resolved — `TestRun_Save_CalledTwice` added; `finalArticulationElements` nil/empty distinction documented
- Architect: **ALIGNED** — package boundary correct; `Promote(ctx)` pattern consistent; one deferred noted (TagValueExplore to schema if second consumer appears)

## Test plan

- [ ] `TestRun_Save_NoStore` — nil store → inline error
- [ ] `TestRun_Save_NoAnalyst` — empty analyst → inline error
- [ ] `TestRun_Save_NoTurns` — 0 turns, named analyst → promotes successfully
- [ ] `TestRun_Save_HappyPath` — 2 observers, 2 cut turns → correct Source, Observer, Mediation, Tags
- [ ] `TestRun_Save_FinalTarget` — articulate then save → Target contains element names
- [ ] `TestRun_Save_ObserverDedup` — alice visited twice → one Source entry
- [ ] `TestRun_Save_CalledTwice` — two saves → two independent traces, distinct UUIDs
- [ ] `TestPromote_EmptySession` — direct `Promote()` call, no turns
- [ ] `TestRun_Help_ShowsSave` — help text contains "save"
- [ ] `go test -race ./...` green; `go vet` clean; 94.2% coverage on explore

Closes #186